### PR TITLE
Piper/use constant for 64k page size

### DIFF
--- a/wasm/constants.py
+++ b/wasm/constants.py
@@ -20,3 +20,7 @@ UINT32_MAX = 2 ** 32 - 1
 INT32_NEGATIVE_ONE = UINT32_MAX
 
 UINT128_CEIL = 2 ** 128
+
+
+# https://webassembly.github.io/spec/core/bikeshed/index.html#memory-instances%E2%91%A0
+PAGE_SIZE_64K = 65536


### PR DESCRIPTION
Builds on #9

## What was wrong?

Re-use of literal `65536` for 64k page size

## How was it fixed?

Replaced with a constant.

#### Cute Animal Picture

![23 shocked surprised](https://user-images.githubusercontent.com/824194/51271537-0d89f300-1985-11e9-8b5c-26cac57980f4.jpg)

