### PR TITLE
Use exhaustion exception over magic string

### DIFF
--- a/wasm/__init__.py
+++ b/wasm/__init__.py
@@ -4502,8 +4502,10 @@ def instantiate_module(store, module, externvalstar):
         ret = spec_instantiate(store, module, externvalstar)
     except EXCEPTIONS_TO_RERAISE:
         raise
-    except Exception as e:
-        return store, "error", e.args[0]
+    except Exception as err:
+        if err.args[0] in {"trap", "exhaustion"}:
+            raise Exception("Invariant: these exceptions should no longer be using the base exception class") from err
+        return store, "error", err.args[0]
 
     store, F, startret = ret
     modinst = F["module"]

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -122,8 +122,6 @@ def run_opcode_action(command, store, module, all_modules, registered_modules):
     else:
         raise Exception(f"Unsupported action type: {command.action.type}")
 
-    if ret == 'exhaustion':
-        raise Exhaustion("Exhaustion happened")
     return ret
 
 


### PR DESCRIPTION
## What was wrong?

The "exhaustion" exception was previously based on a magic string.

## How was it fixed?

Converted all such exceptions to use the `Exhaustion` exception

#### Cute Animal Picture

![i2fun com_surprised_animals_42](https://user-images.githubusercontent.com/824194/51280708-9b71d800-199d-11e9-9169-3211e4b963e6.jpg)

