### PR TITLE
Fill in type hinting for non core library logic and add mypy to CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,6 @@ from setuptools import (
 )
 
 extras_require = {
-    'wasm': [
-        "mypy_extensions>=0.4.1,<1.0.0",
-    ],
     'test': [
         "pytest==4.1.0",
         "pytest-watch==4.2.0",
@@ -51,7 +48,9 @@ setup(
     author_email='ethcalibur+pip@gmail.com',
     url='https://github.com/ethereum/py-wasm',
     include_package_data=True,
-    install_requires=extras_require['wasm'],
+    install_requires=[
+        "mypy_extensions>=0.4.1,<1.0.0",
+    ],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ from setuptools import (
 )
 
 extras_require = {
+    'wasm': [
+        "mypy_extensions>=0.4.1,<1.0.0",
+    ],
     'test': [
         "pytest==4.1.0",
         "pytest-watch==4.2.0",
@@ -16,6 +19,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
+        "mypy==0.660",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",
@@ -47,9 +51,7 @@ setup(
     author_email='ethcalibur+pip@gmail.com',
     url='https://github.com/ethereum/py-wasm',
     include_package_data=True,
-    install_requires=[
-        "eth-utils>=1,<2",
-    ],
+    install_requires=extras_require['wasm'],
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.5, <4',
     extras_require=extras_require,

--- a/tox.ini
+++ b/tox.ini
@@ -41,3 +41,4 @@ extras=lint
 commands=
     flake8 {toxinidir}/wasm {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/wasm {toxinidir}/tests
+    mypy --follow-imports=silent --ignore-missing-imports --disallow-incomplete-defs -p wasm

--- a/wasm/tools/fixtures/datatypes.py
+++ b/wasm/tools/fixtures/datatypes.py
@@ -36,7 +36,7 @@ class Action(NamedTuple):
 class AssertReturnCommand(NamedTuple):
     line: int
     action: Action
-    expected: Expected
+    expected: Tuple[Expected, ...]
 
 
 class AssertInvalidCommand(NamedTuple):
@@ -124,7 +124,7 @@ class AssertReturnCanonicalNan(NamedTuple):
     '''
     line: int
     action: Action
-    expected: Expected
+    expected: Tuple[Expected, ...]
 
 
 class AssertReturnArithmeticNan(NamedTuple):
@@ -146,7 +146,7 @@ class AssertReturnArithmeticNan(NamedTuple):
     '''
     line: int
     action: Action
-    expected: Expected
+    expected: Tuple[Expected, ...]
 
 
 class AssertUnlinkable(NamedTuple):
@@ -165,7 +165,6 @@ class AssertUnlinkable(NamedTuple):
     module_type: str
 
 
-# This uses the alternate syntax since `as` is a reserved word in python.
 class Register(NamedTuple):
     '''
     {
@@ -217,13 +216,24 @@ class AssertUninstantiable(NamedTuple):
     module_type: str
 
 
-ANY_COMMAND = Union[
+TCommand = Union[
     ModuleCommand,
-    AssertReturnCommand,
+    AssertReturnArithmeticNan,
+    ActionCommand,
+    AssertExhaustion,
     AssertInvalidCommand,
+    AssertMalformed,
+    AssertReturnArithmeticNan,
+    AssertReturnCanonicalNan,
+    AssertReturnCommand,
+    AssertTrap,
+    AssertUninstantiable,
+    AssertUnlinkable,
+    ModuleCommand,
+    Register,
 ]
 
 
 class Fixture(NamedTuple):
     file_path: Path
-    commands: Tuple[ANY_COMMAND, ...]
+    commands: Tuple[TCommand, ...]

--- a/wasm/tools/fixtures/generation.py
+++ b/wasm/tools/fixtures/generation.py
@@ -1,3 +1,6 @@
+from pathlib import (
+    Path,
+)
 from typing import (
     Any,
 )
@@ -10,12 +13,12 @@ from .loading import (
 #
 # Pytest fixture generation
 #
-def idfn(fixture_path) -> str:
+def idfn(fixture_path: Path) -> str:
     return str(fixture_path.resolve())
 
 
 def generate_fixture_tests(metafunc: Any,
-                           fixtures_dir: str) -> None:
+                           fixtures_dir: Path) -> None:
     """
     Helper function for use with `pytest_generate_tests` to generate fixture tests.
 

--- a/wasm/tools/fixtures/loading.py
+++ b/wasm/tools/fixtures/loading.py
@@ -1,25 +1,11 @@
-import fnmatch
-import os
 from pathlib import (
     Path,
 )
 from typing import (
-    Iterable,
-)
-
-from eth_utils import (
-    to_tuple,
+    Tuple,
 )
 
 
-@to_tuple
-def recursive_find_files(base_dir: Path, pattern: str) -> Iterable[Path]:
-    for dirpath, _, filenames in os.walk(str(base_dir)):
-        for filename in filenames:
-            if fnmatch.fnmatch(filename, pattern):
-                yield Path(os.path.join(dirpath, filename))
-
-
-def find_json_fixture_files(fixtures_base_dir: Path) -> Iterable[Path]:
+def find_json_fixture_files(fixtures_base_dir: Path) -> Tuple[Path, ...]:
     all_fixture_paths = tuple(fixtures_base_dir.glob('**/*.json'))
     return all_fixture_paths

--- a/wasm/tools/fixtures/numeric.py
+++ b/wasm/tools/fixtures/numeric.py
@@ -1,7 +1,7 @@
 import struct
 
 
-def int_to_float(num_bits, value):
+def int_to_float(num_bits: int, value: int) -> float:
     """
     Convert an integer to the equivalent floating point value.
     """
@@ -15,7 +15,7 @@ def int_to_float(num_bits, value):
     return struct.unpack(unpack_fmt, value.to_bytes(num_bits // 8, 'big'))[0]
 
 
-def get_bit_size(_type) -> int:
+def get_bit_size(_type: str) -> int:
     if _type in {'i32', 'f32'}:
         return 32
     elif _type in {'i64', 'f64'}:

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -4,6 +4,11 @@ import math
 from pathlib import (
     Path,
 )
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 import pytest
 
@@ -51,8 +56,10 @@ class FloatingPointNotImplemented(NotImplementedError):
 
 
 def instantiate_module_from_wasm_file(
-    file_path: Path, store: Store, registered_modules
-):
+        file_path: Path,
+        store: Store,
+        registered_modules: List[Any, ]
+) -> Dict[Any, Any]:
     logger.debug("Loading wasm module from file: %s", file_path.name)
 
     if file_path.suffix != ".wasm":
@@ -68,7 +75,7 @@ def instantiate_module_from_wasm_file(
         wasm.validate_module(module)
 
         # imports preparation
-        externvalstar = []
+        externvalstar: List[Any] = []
         for import_ in module["imports"]:
             if import_["module"] not in registered_modules:
                 raise Unlinkable(f"Unlinkable module: {import_['module']}")


### PR DESCRIPTION
Builds on #19 

## What was wrong?

No `mypy` in ci and missing type hints

## How was it fixed?

Add type hints to everything but `wasm.main` as well as CI run to run type checks on all modules except `wasm.main`

#### Cute Animal Picture

![surprised-animals-15](https://user-images.githubusercontent.com/824194/51346659-6d52cd80-1a5b-11e9-93c4-1c47ce69b6cf.png)

