### PR TITLE
Piper/implement formal data structure for table type

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -2,6 +2,6 @@ from .limits import (  # noqa: F401
     Limits,
 )
 from .tabletype import (  # noqa: F401
-    FuncType,
+    FuncRef,
     TableType,
 )

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -1,3 +1,7 @@
 from .limits import (  # noqa: F401
     Limits,
 )
+from .tabletype import (  # noqa: F401
+    FuncType,
+    TableType,
+)

--- a/wasm/datatypes/tabletype.py
+++ b/wasm/datatypes/tabletype.py
@@ -1,0 +1,23 @@
+from typing import (
+    NamedTuple,
+    Type,
+)
+
+from .limits import (
+    Limits,
+)
+
+
+class FuncType(NamedTuple):
+    """
+    Placeholder until function types get their own formal data structure.
+    """
+    pass
+
+
+class TableType(NamedTuple):
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#table-types%E2%91%A0
+    """
+    limits: Limits
+    elem_type: Type[FuncType]

--- a/wasm/datatypes/tabletype.py
+++ b/wasm/datatypes/tabletype.py
@@ -8,9 +8,9 @@ from .limits import (
 )
 
 
-class FuncType(NamedTuple):
+class FuncRef(NamedTuple):
     """
-    Placeholder until function types get their own formal data structure.
+    Stub data type for function references
     """
     pass
 
@@ -20,4 +20,4 @@ class TableType(NamedTuple):
     https://webassembly.github.io/spec/core/bikeshed/index.html#table-types%E2%91%A0
     """
     limits: Limits
-    elem_type: Type[FuncType]
+    elem_type: Type[FuncRef]

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -2,7 +2,7 @@ import logging
 
 import wasm
 from wasm.datatypes import (
-    FuncType,
+    FuncRef,
     Limits,
     TableType,
 )
@@ -51,7 +51,7 @@ def instantiate_spectest_module(store):
     wasm.alloc_global(store, ["const", "f32"], 0.0)
     wasm.alloc_global(store, ["const", "f64"], 0.0)
     wasm.alloc_table(
-        store, TableType(Limits(10, 20), FuncType)
+        store, TableType(Limits(10, 20), FuncRef)
     )  # max was 30, changed to 20 for import.wast
     moduleinst = {
         "types": [
@@ -118,7 +118,7 @@ def instantiate_test_module(store):
     wasm.alloc_mem(store, Limits(1, None))
     wasm.alloc_global(store, ["const", "i32"], 666)
     wasm.alloc_global(store, ["const", "f32"], 0.0)
-    wasm.alloc_table(store, TableType(Limits(10, None), FuncType))
+    wasm.alloc_table(store, TableType(Limits(10, None), FuncRef))
     moduleinst = {
         "types": [
             [["i32"], []],

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -2,7 +2,9 @@ import logging
 
 import wasm
 from wasm.datatypes import (
+    FuncType,
     Limits,
+    TableType,
 )
 
 
@@ -49,7 +51,7 @@ def instantiate_spectest_module(store):
     wasm.alloc_global(store, ["const", "f32"], 0.0)
     wasm.alloc_global(store, ["const", "f64"], 0.0)
     wasm.alloc_table(
-        store, [Limits(10, 20), "anyfunc"]
+        store, TableType(Limits(10, 20), FuncType)
     )  # max was 30, changed to 20 for import.wast
     moduleinst = {
         "types": [
@@ -116,7 +118,7 @@ def instantiate_test_module(store):
     wasm.alloc_mem(store, Limits(1, None))
     wasm.alloc_global(store, ["const", "i32"], 666)
     wasm.alloc_global(store, ["const", "f32"], 0.0)
-    wasm.alloc_table(store, [Limits(10, None), "anyfunc"])
+    wasm.alloc_table(store, TableType(Limits(10, None), FuncType))
     moduleinst = {
         "types": [
             [["i32"], []],


### PR DESCRIPTION
Builds on #21 

## What was wrong?

The Web Assembly spec defines a data structure *Table Type*: https://webassembly.github.io/spec/core/bikeshed/index.html#table-types%E2%91%A0

This was being internally represented as a length-2 list:  `[Limits(...), "anyfunc"]`

This data structure is mutable **and** it uses a magic string to represent the element type.

## How was it fixed?

Added a *stub* data type `FuncType` to be used as the element type and then updated all representations of a table type to use a new `TableType` data structure which is a `NamedTuple`.

#### Cute Animal Picture

![surprised-shocked-animals-funny-3__700](https://user-images.githubusercontent.com/824194/51352889-3507bb00-1a6c-11e9-8921-c30a8a58d06c.jpg)

