### PR TITLE
Implement formal data structure for function type

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -1,3 +1,6 @@
+from .func_type import (  # noqa: F401
+    FuncType,
+)
 from .global_type import (  # noqa: F401
     GlobalType,
 )

--- a/wasm/datatypes/func_type.py
+++ b/wasm/datatypes/func_type.py
@@ -1,0 +1,16 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+)
+
+from .val_type import (
+    ValType,
+)
+
+
+class FuncType(NamedTuple):
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#function-types%E2%91%A0
+    """
+    params: Tuple[ValType, ...]
+    results: Tuple[ValType, ...]

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -3,6 +3,7 @@ import logging
 import wasm
 from wasm.datatypes import (
     FuncRef,
+    FuncType,
     GlobalType,
     Limits,
     MemoryType,
@@ -43,13 +44,13 @@ def instantiate_spectest_module(store):
         logger.debug('print: %s', arg)
         return store, []
 
-    wasm.alloc_func(store, [[ValType.i32], []], spectest__print_i32)
-    wasm.alloc_func(store, [[ValType.i64], []], spectest__print_i64)
-    wasm.alloc_func(store, [[ValType.f32], []], spectest__print_f32)
-    wasm.alloc_func(store, [[ValType.f64], []], spectest__print_f64)
-    wasm.alloc_func(store, [[ValType.i32, ValType.f32], []], spectest__print_i32_f32)
-    wasm.alloc_func(store, [[ValType.f64, ValType.f64], []], spectest__print_f64_f64)
-    wasm.alloc_func(store, [[], []], spectest__print)
+    wasm.alloc_func(store, FuncType((ValType.i32,), ()), spectest__print_i32)
+    wasm.alloc_func(store, FuncType((ValType.i64,), ()), spectest__print_i64)
+    wasm.alloc_func(store, FuncType((ValType.f32,), ()), spectest__print_f32)
+    wasm.alloc_func(store, FuncType((ValType.f64,), ()), spectest__print_f64)
+    wasm.alloc_func(store, FuncType((ValType.i32, ValType.f32), ()), spectest__print_i32_f32)
+    wasm.alloc_func(store, FuncType((ValType.f64, ValType.f64), ()), spectest__print_f64_f64)
+    wasm.alloc_func(store, FuncType((), ()), spectest__print)
 
     # min:1,max:2 required by import.wast:
     wasm.alloc_mem(store, MemoryType(1, 2))
@@ -64,13 +65,13 @@ def instantiate_spectest_module(store):
     )  # max was 30, changed to 20 for import.wast
     moduleinst = {
         "types": [
-            [[ValType.i32], []],
-            [[ValType.i64], []],
-            [[ValType.i32], []],
-            [[ValType.f64], []],
-            [[ValType.i32, ValType.f32], []],
-            [[ValType.f64, ValType.f64], []],
-            [[], []],
+            FuncType((ValType.i32,), ()),
+            FuncType((ValType.i64,), ()),
+            FuncType((ValType.f32,), ()),
+            FuncType((ValType.f64,), ()),
+            FuncType((ValType.i32, ValType.f32), ()),
+            FuncType((ValType.f64, ValType.f64), ()),
+            FuncType((), ()),
         ],
         "funcaddrs": [0, 1, 2, 3, 4, 5, 6],
         "tableaddrs": [0],
@@ -117,25 +118,26 @@ def instantiate_test_module(store):
     def test__func_i64_i64(store, arg):
         pass
 
-    wasm.alloc_func(store, [[], []], test__func)
-    wasm.alloc_func(store, [[ValType.i32], []], test__func_i32)
-    wasm.alloc_func(store, [[ValType.f32], []], test__func_f32)
-    wasm.alloc_func(store, [[], [ValType.i32]], test__func__i32)
-    wasm.alloc_func(store, [[], [ValType.f32]], test__func__f32)
-    wasm.alloc_func(store, [[ValType.i32], [ValType.i32]], test__func_i32_i32)
-    wasm.alloc_func(store, [[ValType.i64], [ValType.i64]], test__func_i64_i64)
+    wasm.alloc_func(store, FuncType((), ()), test__func)
+    wasm.alloc_func(store, FuncType((ValType.i32,), ()), test__func_i32)
+    wasm.alloc_func(store, FuncType((ValType.f32,), ()), test__func_f32)
+    wasm.alloc_func(store, FuncType((), (ValType.i32,)), test__func__i32)
+    wasm.alloc_func(store, FuncType((), (ValType.f32,)), test__func__f32)
+    wasm.alloc_func(store, FuncType((ValType.i32,), (ValType.i32,)), test__func_i32_i32)
+    wasm.alloc_func(store, FuncType((ValType.i64,), (ValType.i64,)), test__func_i64_i64)
     wasm.alloc_mem(store, MemoryType(1, None))
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.i32), 666)
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.f32), 0.0)
     wasm.alloc_table(store, TableType(Limits(10, None), FuncRef))
     moduleinst = {
         "types": [
-            [[ValType.i32], []],
-            [[ValType.f32], []],
-            [[], [ValType.i32]],
-            [[], [ValType.f32]],
-            [[ValType.i32], [ValType.i32]],
-            [[ValType.i64], [ValType.i64]],
+            FuncType((), ()),
+            FuncType((ValType.i32,), ()),
+            FuncType((ValType.f32,), ()),
+            FuncType((), (ValType.i32,)),
+            FuncType((), (ValType.f32,)),
+            FuncType((ValType.i32,), (ValType.i32,)),
+            FuncType((ValType.i64,), (ValType.i64,)),
         ],
         "funcaddrs": [0, 1, 2, 3, 4, 5, 6],
         "tableaddrs": [0],


### PR DESCRIPTION
Builds from #25

## What was wrong?

The WebAssembly spec defines a FuncType data structure which has two arrays of ValTypes for the function parameters and return values..  This was currently being represented by a length-2 list with two lists holding the ValTypes

## How was it fixed?

Created a `FuncType` named tuple which stores the parameters and return types in tuples to remove mutability concerns.  Updated code to use this new data type.

#### Cute Animal Picture

![surprised-animals-18-1](https://user-images.githubusercontent.com/824194/51412715-be30f780-1b29-11e9-84ea-44b3e306a8c6.jpg)

