### PR TITLE
Implement formal data structure for imports.

### DIFF
--- a/wasm/_utils/validation.py
+++ b/wasm/_utils/validation.py
@@ -2,7 +2,7 @@ from collections import (
     Counter,
 )
 from typing import (
-    Sequence,
+    Iterable,
     Tuple,
     TypeVar,
 )
@@ -10,7 +10,7 @@ from typing import (
 TVal = TypeVar("TVal")
 
 
-def get_duplicates(seq: Sequence[TVal]) -> Tuple[TVal, ...]:
+def get_duplicates(seq: Iterable[TVal]) -> Tuple[TVal, ...]:
     return tuple(
         value
         for value, count

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -7,11 +7,15 @@ from .func_type import (  # noqa: F401
 from .global_type import (  # noqa: F401
     GlobalType,
 )
+from .imports import (  # noqa: F401
+    Import,
+)
 from .indices import (  # noqa: F401
     FuncIdx,
     GlobalIdx,
     MemoryIdx,
     TableIdx,
+    TypeIdx,
 )
 from .limits import (  # noqa: F401
     Limits,

--- a/wasm/datatypes/imports.py
+++ b/wasm/datatypes/imports.py
@@ -1,0 +1,42 @@
+from typing import (
+    NamedTuple,
+)
+
+from wasm.typing import (
+    ImportDesc,
+)
+
+from .global_type import (
+    GlobalType,
+)
+from .indices import (
+    TypeIdx,
+)
+from .memory_type import (
+    MemoryType,
+)
+from .table_type import (
+    TableType,
+)
+
+
+class Import(NamedTuple):
+    module: str
+    name: str
+    desc: ImportDesc
+
+    @property
+    def is_function(self):
+        return isinstance(self.desc, TypeIdx)
+
+    @property
+    def is_global(self):
+        return isinstance(self.desc, GlobalType)
+
+    @property
+    def is_memory(self):
+        return isinstance(self.desc, MemoryType)
+
+    @property
+    def is_table(self):
+        return isinstance(self.desc, TableType)

--- a/wasm/datatypes/indices.py
+++ b/wasm/datatypes/indices.py
@@ -2,7 +2,7 @@ class FuncIdx(int):
     pass
 
 
-class TableIdx(int):
+class GlobalIdx(int):
     pass
 
 
@@ -10,5 +10,9 @@ class MemoryIdx(int):
     pass
 
 
-class GlobalIdx(int):
+class TableIdx(int):
+    pass
+
+
+class TypeIdx(int):
     pass

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -714,7 +714,7 @@ def spec_validate_module(mod: Module) -> List[List[ExternType]]:
     itstar: List[ExternType] = []
     for import_ in mod["imports"]:
         if import_.is_function:
-            if len(mod["types"]) <= import_.desc:
+            if import_.desc >= len(mod["types"]):
                 # this was not explicit in spec
                 raise InvalidModule(
                     f"Function import out of range: {import_.desc} > "
@@ -2805,29 +2805,29 @@ def spec_externtype_matching(externtype1, externtype2):
         raise Unlinkable(
             f"Mismatch in extern types: {type(externtype1)} != {type(externtype2)}"
         )
-    elif isinstance(externtype1, FuncType) and isinstance(externtype2, FuncType):
+    elif isinstance(externtype1, FuncType):
         if externtype1 == externtype2:
             return "<="
         else:
             raise Unlinkable(f"Function types not equal: {externtype1} != {externtype2}")
-    elif isinstance(externtype1, TableType) and isinstance(externtype2, TableType):
+    elif isinstance(externtype1, TableType):
         spec_externtype_matching_limits(externtype1.limits, externtype2.limits)
 
-        if externtype1.elem_type is externtype1.elem_type:
+        if externtype1.elem_type is externtype2.elem_type:
             return "<="
         else:
             raise Unlinkable(
                 f"Table element type mismatch: {externtype1.elem_type} != "
                 f"{externtype2.elem_type}"
             )
-    elif isinstance(externtype1, MemoryType) and isinstance(externtype2, MemoryType):
+    elif isinstance(externtype1, MemoryType):
         if spec_externtype_matching_limits(externtype1, externtype2) == "<=":
             return "<="
         else:
             # TODO: This code path doesn't appear to be excercised and it
             # likely isn't an invariant.
             raise Exception("Invariant")
-    elif isinstance(externtype1, GlobalType) and isinstance(externtype2, GlobalType):
+    elif isinstance(externtype1, GlobalType):
         if externtype1 == externtype2:
             return "<="
         else:
@@ -4565,8 +4565,9 @@ def module_imports(module):
         )
 
     result = []
-    for importi, importstar in zip(importstar, externtypestar):
-        resutli = [immporti.module, importi.name, externtypei]
+    for importi, externtypei in zip(importstar, externtypestar):
+        # This code path appears to be missing test coverage.
+        resutli = [importi.module, importi.name, externtypei]
         result += resulti
     return result
 

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -74,13 +74,13 @@ def instantiate_module_from_wasm_file(
         # imports preparation
         externvalstar: List[Any] = []
         for import_ in module["imports"]:
-            if import_["module"] not in registered_modules:
-                raise Unlinkable(f"Unlinkable module: {import_['module']}")
+            if import_.module not in registered_modules:
+                raise Unlinkable(f"Unlinkable module: {import_.module}")
 
-            sub_module = registered_modules[import_["module"]]
+            sub_module = registered_modules[import_.module]
 
             for export in sub_module["exports"]:
-                if export.name == import_["name"]:
+                if export.name == import_.name:
                     externval = export.desc
                     break
             else:

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -9,9 +9,14 @@ from typing import (
 if TYPE_CHECKING:
     from wasm.datatypes import (  # noqa: F401
         FuncIdx,
+        FuncType,
         GlobalIdx,
+        GlobalType,
         MemoryIdx,
+        MemoryType,
         TableIdx,
+        TableType,
+        TypeIdx,
     )
 
 
@@ -25,6 +30,22 @@ ExportDesc = Union[
     'GlobalIdx',
     'MemoryIdx',
     'TableIdx',
+]
+
+
+ImportDesc = Union[
+    'TypeIdx',
+    'TableType',
+    'MemoryType',
+    'GlobalType',
+]
+
+
+ExternType = Union[
+    'FuncType',
+    'TableType',
+    'MemoryType',
+    'GlobalType',
 ]
 
 


### PR DESCRIPTION
## What was wrong?

The WebAssembly spec defines a formal data structure for Imports.  Current codebase used a mixture of lists and dictionaries to represent them which results in heavy mutability and difficult readability.

## How was it fixed?

Implemented an Import type in roughly the same manner as #27 with a `NamedTuple` for the Import data structure and an additional `int` subclass, `TypeIdx` for the new indices type that needed to be supported.

#### Cute Animal Picture

![14628390535_503e98f8e1_b](https://user-images.githubusercontent.com/824194/51433600-0aa03400-1c0b-11e9-83cd-97e1c4718a64.jpg)

