### PR TITLE
Implement formal data structures for Instruction types.

### DIFF
--- a/tests/core/parsers/test_numeric_parsers.py
+++ b/tests/core/parsers/test_numeric_parsers.py
@@ -1,0 +1,28 @@
+import io
+
+import pytest
+
+from wasm.exceptions import (
+    MalformedModule,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+from wasm.parsers.numeric import (
+    parse_numeric_constant_instruction,
+)
+
+
+@pytest.mark.parametrize(
+    "opcode,raw_value",
+    (
+        # exceeds allowed bit width
+        (BinaryOpcode.I32_CONST, b'\x80\x80\x80\x80\x80\x00'),
+        (BinaryOpcode.I32_CONST, b'\xff\xff\xff\xff\x0f'),
+        (BinaryOpcode.I64_CONST, b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x00'),
+        (BinaryOpcode.I64_CONST, b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x0f'),
+    ),
+)
+def test_parse_numeric_constant_instruction(opcode, raw_value):
+    with pytest.raises(MalformedModule):
+        parse_numeric_constant_instruction(opcode, io.BytesIO(raw_value))

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -7,6 +7,9 @@ from .exports import (  # noqa: F401
 from .func_type import (  # noqa: F401
     FuncType,
 )
+from .function import (  # noqa: F401
+    ModuleFunction,
+)
 from .global_type import (  # noqa: F401
     GlobalType,
 )
@@ -16,6 +19,8 @@ from .imports import (  # noqa: F401
 from .indices import (  # noqa: F401
     FuncIdx,
     GlobalIdx,
+    LabelIdx,
+    LocalIdx,
     MemoryIdx,
     TableIdx,
     TypeIdx,

--- a/wasm/datatypes/func_type.py
+++ b/wasm/datatypes/func_type.py
@@ -13,4 +13,5 @@ class FuncType(NamedTuple):
     https://webassembly.github.io/spec/core/bikeshed/index.html#function-types%E2%91%A0
     """
     params: Tuple[ValType, ...]
+    # TODO: rename to result_type to be more inline with other variable naming
     results: Tuple[ValType, ...]

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -1,0 +1,26 @@
+from typing import (
+    TYPE_CHECKING,
+    NamedTuple,
+    Tuple,
+)
+
+from .indices import (
+    TypeIdx,
+)
+from .val_type import (
+    ValType,
+)
+
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        Instruction,
+    )
+
+
+class ModuleFunction(NamedTuple):
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#functions%E2%91%A0
+    """
+    type: TypeIdx
+    locals: Tuple[ValType, ...]
+    expr: Tuple['Instruction', ...]

--- a/wasm/instructions/__init__.py
+++ b/wasm/instructions/__init__.py
@@ -1,0 +1,91 @@
+from typing import (
+    Union,
+)
+
+from .control import (  # noqa: F401
+    BaseInstruction,
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Call,
+    CallIndirect,
+    Else,
+    End,
+    If,
+    Loop,
+    Nop,
+    Return,
+    Unreachable,
+)
+from .memory import (  # noqa: F401
+    MemoryAction,
+    MemoryArg,
+    MemoryGrow,
+    MemoryOp,
+    MemorySize,
+)
+from .numeric import (  # noqa: F401
+    BinOp,
+    Comparison,
+    Convert,
+    Demote,
+    Extend,
+    F32Const,
+    F64Const,
+    I32Const,
+    I64Const,
+    Promote,
+    Reinterpret,
+    RelOp,
+    TestOp,
+    Truncate,
+    UnOp,
+    Wrap,
+)
+from .parametric import (
+    Drop,
+    Select,
+)
+from .variable import (  # noqa: F401
+    GlobalOp,
+    LocalOp,
+)
+
+
+Instruction = Union[
+    BaseInstruction,
+    I32Const, I64Const,
+    F32Const, F64Const,
+    UnOp,
+    BinOp,
+    RelOp,
+    TestOp,
+    Wrap,
+    Extend,
+    Truncate,
+    Convert,
+    Promote,
+    Demote,
+    Reinterpret,
+    LocalOp,
+    GlobalOp,
+    MemoryOp,
+    MemoryGrow,
+    MemorySize,
+    Drop,
+    Select,
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Loop,
+    If,
+    Else,
+    End,
+    Call,
+    CallIndirect,
+    Nop,
+    Unreachable,
+    Return,
+]

--- a/wasm/instructions/base.py
+++ b/wasm/instructions/base.py
@@ -1,0 +1,47 @@
+from abc import ABC
+from typing import (
+    Any,
+    Type,
+    TypeVar,
+)
+
+from wasm._utils.interned import (
+    Interned,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+
+class BaseInstruction(ABC):
+    """
+    Abstract base class that all instruction classes are registered with to
+    allow for isinstance checks.
+    """
+    opcode: BinaryOpcode
+
+
+TInstruction = TypeVar("TInstruction")
+
+
+def register(cls: Type[TInstruction]) -> Type[TInstruction]:
+    """
+    Class decorator which registeres the class with the `BaseInstruction` base
+    class.
+    """
+    BaseInstruction.register(cls)
+    return cls
+
+
+class SimpleOp(Interned):
+    """
+    Base class for opcodes which don't have any arguments or state whos
+    instances can be reused.
+    """
+    opcode: BinaryOpcode
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    def __eq__(self, other: Any) -> bool:
+        return self is other

--- a/wasm/instructions/control.py
+++ b/wasm/instructions/control.py
@@ -1,0 +1,185 @@
+from typing import (
+    TYPE_CHECKING,
+    NamedTuple,
+    Sequence,
+    Tuple,
+    cast,
+)
+
+from wasm._utils.interned import (
+    Interned,
+)
+from wasm.datatypes import (
+    FuncIdx,
+    LabelIdx,
+    TypeIdx,
+    ValType,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .base import (
+    BaseInstruction,
+    SimpleOp,
+    register,
+)
+
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        Instruction,
+    )
+
+
+def stringify_instructions(instructions: Sequence['Instruction']) -> str:
+    return ' > '.join(map(str, instructions))
+
+
+@register
+class Block(NamedTuple):
+    result_type: Tuple[ValType, ...]
+    instructions: Tuple[BaseInstruction, ...]
+
+    @property
+    def opcode(self) -> BinaryOpcode:
+        return BinaryOpcode.BLOCK
+
+    def __str__(self) -> str:
+        rt = f"({','.join((v.value for v in self.result_type))})"
+        return f"{self.opcode.text}[rt={rt},expr={stringify_instructions(self.instructions)}]"
+
+
+@register
+class Br(Interned):
+    opcode = BinaryOpcode.BR
+
+    def __init__(self, label_idx: LabelIdx) -> None:
+        self.label_idx = label_idx
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.label_idx}]"
+
+
+@register
+class BrTable(Interned):
+    opcode = BinaryOpcode.BR_TABLE
+
+    def __init__(self,
+                 label_indices: Tuple[LabelIdx, ...],
+                 default_idx: LabelIdx) -> None:
+        self.label_indices = label_indices
+        self.default_idx = default_idx
+
+    @property
+    def opcode(self) -> BinaryOpcode:
+        return BinaryOpcode.BR_TABLE
+
+    def __str__(self) -> str:
+        return (
+            f"{self.opcode.text}["
+            f"labels={':'.join((str(l) for l in self.label_indices))},"
+            f"default={self.default_idx}]"
+        )
+
+
+@register
+class BrIf(Interned):
+    opcode = BinaryOpcode.BR_IF
+
+    def __init__(self, label_idx: LabelIdx) -> None:
+        self.label_idx = label_idx
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.label_idx}]"
+
+
+@register
+class Loop(NamedTuple):
+    result_type: Tuple[ValType, ...]
+    instructions: Tuple[BaseInstruction, ...]
+
+    @property
+    def opcode(self) -> BinaryOpcode:
+        return BinaryOpcode.LOOP
+
+    def __str__(self) -> str:
+        rt = f"({','.join((v.value for v in self.result_type))})"
+        return f"{self.opcode.text}[rt={rt},expr={self.instructions}]"
+
+
+@register
+class If(NamedTuple):
+    result_type: Tuple[ValType, ...]
+    instructions: Tuple[BaseInstruction, ...]
+    else_instructions: Tuple[BaseInstruction, ...]
+
+    @property
+    def opcode(self) -> BinaryOpcode:
+        return BinaryOpcode.IF
+
+    def __str__(self) -> str:
+        rt = f"({','.join((v.value for v in self.result_type))})"
+        if self.else_instructions:
+            return (
+                f"{self.opcode.text}["
+                f"rt={rt},"
+                f"main={stringify_instructions(self.instructions)},"
+                f"else={stringify_instructions(self.else_instructions)}]"
+            )
+        else:
+            return f"{self.opcode.text}[rt={rt},main={self.instructions}]"
+
+
+@register
+class Else(SimpleOp):
+    opcode = BinaryOpcode.ELSE
+
+    @classmethod
+    def as_tail(cls) -> Tuple['BaseInstruction', ...]:
+        return cast(Tuple['BaseInstruction', ...], (cls(),))
+
+
+@register
+class End(SimpleOp):
+    opcode = BinaryOpcode.END
+
+    @classmethod
+    def as_tail(cls) -> Tuple['BaseInstruction', ...]:
+        return cast(Tuple['BaseInstruction', ...], (cls(),))
+
+
+@register
+class CallIndirect(Interned):
+    opcode = BinaryOpcode.CALL_INDIRECT
+
+    def __init__(self, type_idx: TypeIdx) -> None:
+        self.type_idx = type_idx
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.type_idx}]"
+
+
+@register
+class Nop(SimpleOp):
+    opcode = BinaryOpcode.NOP
+
+
+@register
+class Unreachable(SimpleOp):
+    opcode = BinaryOpcode.UNREACHABLE
+
+
+@register
+class Call(Interned):
+    opcode = BinaryOpcode.CALL
+
+    def __init__(self, func_idx: FuncIdx) -> None:
+        self.func_idx = func_idx
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.func_idx}]"
+
+
+@register
+class Return(SimpleOp):
+    opcode = BinaryOpcode.RETURN

--- a/wasm/instructions/memory.py
+++ b/wasm/instructions/memory.py
@@ -1,0 +1,130 @@
+import collections
+import enum
+from typing import (
+    Optional,
+)
+
+from wasm._utils.interned import (
+    Interned,
+)
+from wasm.datatypes import (
+    BitSize,
+    ValType,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+from wasm.typing import (
+    UInt32,
+)
+
+from .base import (
+    SimpleOp,
+    register,
+)
+
+
+class MemoryArg(Interned, collections.abc.Hashable):
+    def __init__(self,
+                 offset: UInt32,
+                 align: UInt32) -> None:
+        self.offset = offset
+        self.align = align
+
+    def __hash__(self) -> int:
+        return hash((self.offset, self.align))
+
+
+class MemoryAction(enum.Enum):
+    load = 'load'
+    store = 'store'
+
+
+@register
+class MemoryOp(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 action: MemoryAction,
+                 memarg: MemoryArg,
+                 valtype: ValType,
+                 declared_bit_size: Optional[BitSize],
+                 signed: Optional[bool]) -> None:
+        self.opcode = opcode
+        self.action = action
+        self.memarg = memarg
+        self.valtype = valtype
+        self.declared_bit_size = declared_bit_size
+        self.signed = signed
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[align={self.memarg.align},offset={self.memarg.offset}]"
+
+    @property
+    def memory_bit_size(self) -> BitSize:
+        if self.declared_bit_size is None:
+            return self.valtype.bit_size
+        else:
+            return self.declared_bit_size
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    memarg: MemoryArg) -> 'MemoryOp':
+        if opcode is BinaryOpcode.F32_LOAD:
+            return cls(opcode, MemoryAction.load, memarg, ValType.f32, None, None)
+        elif opcode is BinaryOpcode.F32_STORE:
+            return cls(opcode, MemoryAction.store, memarg, ValType.f32, None, None)
+        elif opcode is BinaryOpcode.F64_LOAD:
+            return cls(opcode, MemoryAction.load, memarg, ValType.f64, None, None)
+        elif opcode is BinaryOpcode.F64_STORE:
+            return cls(opcode, MemoryAction.store, memarg, ValType.f64, None, None)
+        elif opcode is BinaryOpcode.I32_LOAD:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i32, None, None)
+        elif opcode is BinaryOpcode.I32_LOAD16_S:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i32, BitSize.b16, True)
+        elif opcode is BinaryOpcode.I32_LOAD16_U:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i32, BitSize.b16, False)
+        elif opcode is BinaryOpcode.I32_LOAD8_S:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i32, BitSize.b8, True)
+        elif opcode is BinaryOpcode.I32_LOAD8_U:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i32, BitSize.b8, False)
+        elif opcode is BinaryOpcode.I32_STORE:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i32, None, None)
+        elif opcode is BinaryOpcode.I32_STORE16:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i32, BitSize.b16, None)
+        elif opcode is BinaryOpcode.I32_STORE8:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i32, BitSize.b8, None)
+        elif opcode is BinaryOpcode.I64_LOAD:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, None, None)
+        elif opcode is BinaryOpcode.I64_LOAD16_S:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b16, True)
+        elif opcode is BinaryOpcode.I64_LOAD16_U:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b16, False)
+        elif opcode is BinaryOpcode.I64_LOAD32_S:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b32, True)
+        elif opcode is BinaryOpcode.I64_LOAD32_U:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b32, False)
+        elif opcode is BinaryOpcode.I64_LOAD8_S:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b8, True)
+        elif opcode is BinaryOpcode.I64_LOAD8_U:
+            return cls(opcode, MemoryAction.load, memarg, ValType.i64, BitSize.b8, False)
+        elif opcode is BinaryOpcode.I64_STORE:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i64, None, None)
+        elif opcode is BinaryOpcode.I64_STORE16:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i64, BitSize.b16, None)
+        elif opcode is BinaryOpcode.I64_STORE32:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i64, BitSize.b32, None)
+        elif opcode is BinaryOpcode.I64_STORE8:
+            return cls(opcode, MemoryAction.store, memarg, ValType.i64, BitSize.b8, None)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class MemorySize(SimpleOp):
+    opcode = BinaryOpcode.MEMORY_SIZE
+
+
+@register
+class MemoryGrow(SimpleOp):
+    opcode = BinaryOpcode.MEMORY_GROW

--- a/wasm/instructions/numeric.py
+++ b/wasm/instructions/numeric.py
@@ -1,0 +1,558 @@
+import enum
+from typing import (
+    NamedTuple,
+    Optional,
+)
+
+from wasm._utils.interned import (
+    Interned,
+)
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+from wasm.typing import (
+    Float32,
+    Float64,
+    UInt32,
+    UInt64,
+)
+
+from .base import (
+    SimpleOp,
+    register,
+)
+
+
+#
+# Numeric
+#
+@register
+class I32Const(NamedTuple):
+    opcode: BinaryOpcode
+    valtype: ValType
+    value: UInt32
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.value}]"
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    value: UInt32) -> 'I32Const':
+        if opcode is not BinaryOpcode.I32_CONST:
+            raise TypeError(f"Invalid opcode: {opcode}")
+        return cls(opcode, ValType.i32, value)
+
+
+@register
+class I64Const(NamedTuple):
+    opcode: BinaryOpcode
+    valtype: ValType
+    value: UInt64
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.value}]"
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    value: UInt64) -> 'I64Const':
+        if opcode is not BinaryOpcode.I64_CONST:
+            raise TypeError(f"Invalid opcode: {opcode}")
+        return cls(opcode, ValType.i64, value)
+
+
+@register
+class F32Const(NamedTuple):
+    opcode: BinaryOpcode
+    valtype: ValType
+    value: Float32
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.value}]"
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    value: Float32) -> 'F32Const':
+        if opcode is not BinaryOpcode.F32_CONST:
+            raise TypeError(f"Invalid opcode: {opcode}")
+        return cls(opcode, ValType.f32, value)
+
+
+@register
+class F64Const(NamedTuple):
+    opcode: BinaryOpcode
+    valtype: ValType
+    value: Float64
+
+    def __str__(self) -> str:
+        return f"{self.opcode.text}[{self.value}]"
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    value: Float64) -> 'F64Const':
+        if opcode is not BinaryOpcode.F64_CONST:
+            raise TypeError(f"Invalid opcode: {opcode}")
+        return cls(opcode, ValType.f64, value)
+
+
+class Comparison(enum.Enum):
+    eq = 'eq'
+    ne = 'ne'
+    lt = 'lt'
+    gt = 'gt'
+    le = 'le'
+    ge = 'ge'
+    lt_s = 'lt_s'
+    lt_u = 'lt_u'
+    gt_s = 'gt_s'
+    gt_u = 'gt_u'
+    le_s = 'le_s'
+    le_u = 'le_u'
+    ge_s = 'ge_s'
+    ge_u = 'ge_u'
+
+    @property
+    def signed(self) -> Optional[bool]:
+        if self is Comparison.eq:
+            return None
+        elif self is Comparison.ne:
+            return None
+        elif self in {Comparison.lt_s, Comparison.gt_s, Comparison.le_s, Comparison.ge_s}:
+            return True
+        elif self in {Comparison.lt_u, Comparison.gt_u, Comparison.le_u, Comparison.ge_u}:
+            return False
+        else:
+            raise Exception("Invariant")
+
+
+# TODO: All of the following numeric operation classes could be
+# converted to a singleton pattern to reduce object churn.  This could also
+# include the classes themselves handling extracting things like valtype or the
+# comparison from the opcode itself rather than how it is currently done in the
+# parser, resulting in stronger guarantees that these classes cannot be
+# instantiated with invalid parameters.
+@register
+class RelOp(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType,
+                 comparison: Comparison) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+        self.comparison = comparison
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'RelOp':
+        # i32relop
+        if opcode is BinaryOpcode.I32_EQ:
+            return cls(opcode, ValType.i32, Comparison.eq)
+        elif opcode is BinaryOpcode.I32_NE:
+            return cls(opcode, ValType.i32, Comparison.ne)
+        elif opcode is BinaryOpcode.I32_LT_S:
+            return cls(opcode, ValType.i32, Comparison.lt_s)
+        elif opcode is BinaryOpcode.I32_LT_U:
+            return cls(opcode, ValType.i32, Comparison.lt_u)
+        elif opcode is BinaryOpcode.I32_GT_S:
+            return cls(opcode, ValType.i32, Comparison.gt_s)
+        elif opcode is BinaryOpcode.I32_GT_U:
+            return cls(opcode, ValType.i32, Comparison.gt_u)
+        elif opcode is BinaryOpcode.I32_LE_S:
+            return cls(opcode, ValType.i32, Comparison.le_s)
+        elif opcode is BinaryOpcode.I32_LE_U:
+            return cls(opcode, ValType.i32, Comparison.le_u)
+        elif opcode is BinaryOpcode.I32_GE_S:
+            return cls(opcode, ValType.i32, Comparison.ge_s)
+        elif opcode is BinaryOpcode.I32_GE_U:
+            return cls(opcode, ValType.i32, Comparison.ge_u)
+        # i64relop
+        elif opcode is BinaryOpcode.I64_EQ:
+            return cls(opcode, ValType.i64, Comparison.eq)
+        elif opcode is BinaryOpcode.I64_NE:
+            return cls(opcode, ValType.i64, Comparison.ne)
+        elif opcode is BinaryOpcode.I64_LT_S:
+            return cls(opcode, ValType.i64, Comparison.lt_s)
+        elif opcode is BinaryOpcode.I64_LT_U:
+            return cls(opcode, ValType.i64, Comparison.lt_u)
+        elif opcode is BinaryOpcode.I64_GT_S:
+            return cls(opcode, ValType.i64, Comparison.gt_s)
+        elif opcode is BinaryOpcode.I64_GT_U:
+            return cls(opcode, ValType.i64, Comparison.gt_u)
+        elif opcode is BinaryOpcode.I64_LE_S:
+            return cls(opcode, ValType.i64, Comparison.le_s)
+        elif opcode is BinaryOpcode.I64_LE_U:
+            return cls(opcode, ValType.i64, Comparison.le_u)
+        elif opcode is BinaryOpcode.I64_GE_S:
+            return cls(opcode, ValType.i64, Comparison.ge_s)
+        elif opcode is BinaryOpcode.I64_GE_U:
+            return cls(opcode, ValType.i64, Comparison.ge_u)
+        # f32relop
+        elif opcode is BinaryOpcode.F32_EQ:
+            return cls(opcode, ValType.f32, Comparison.eq)
+        elif opcode is BinaryOpcode.F32_NE:
+            return cls(opcode, ValType.f32, Comparison.ne)
+        elif opcode is BinaryOpcode.F32_LT:
+            return cls(opcode, ValType.f32, Comparison.lt)
+        elif opcode is BinaryOpcode.F32_GT:
+            return cls(opcode, ValType.f32, Comparison.gt)
+        elif opcode is BinaryOpcode.F32_LE:
+            return cls(opcode, ValType.f32, Comparison.le)
+        elif opcode is BinaryOpcode.F32_GE:
+            return cls(opcode, ValType.f32, Comparison.ge)
+        # f64relop
+        elif opcode is BinaryOpcode.F64_EQ:
+            return cls(opcode, ValType.f64, Comparison.eq)
+        elif opcode is BinaryOpcode.F64_NE:
+            return cls(opcode, ValType.f64, Comparison.ne)
+        elif opcode is BinaryOpcode.F64_LT:
+            return cls(opcode, ValType.f64, Comparison.lt)
+        elif opcode is BinaryOpcode.F64_GT:
+            return cls(opcode, ValType.f64, Comparison.gt)
+        elif opcode is BinaryOpcode.F64_LE:
+            return cls(opcode, ValType.f64, Comparison.le)
+        elif opcode is BinaryOpcode.F64_GE:
+            return cls(opcode, ValType.f64, Comparison.ge)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class UnOp(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'UnOp':
+        # i32
+        if opcode is BinaryOpcode.I32_CLZ:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_CTZ:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_POPCNT:
+            return cls(opcode, ValType.i32)
+        # i64
+        elif opcode is BinaryOpcode.I64_CLZ:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_CTZ:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_POPCNT:
+            return cls(opcode, ValType.i64)
+        # f32
+        elif opcode is BinaryOpcode.F32_ABS:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_NEG:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_CEIL:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_FLOOR:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_TRUNC:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_NEAREST:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_SQRT:
+            return cls(opcode, ValType.f32)
+        # f64
+        elif opcode is BinaryOpcode.F64_ABS:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_NEG:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_CEIL:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_FLOOR:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_TRUNC:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_NEAREST:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_SQRT:
+            return cls(opcode, ValType.f64)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class BinOp(Interned):
+    def __init__(self, opcode: BinaryOpcode, valtype: ValType) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'BinOp':
+        # i32
+        if opcode is BinaryOpcode.I32_ADD:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_SUB:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_MUL:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_DIV_S:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_DIV_U:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_REM_S:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_REM_U:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_AND:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_OR:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_XOR:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_SHL:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_SHR_S:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_SHR_U:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_ROTL:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I32_ROTR:
+            return cls(opcode, ValType.i32)
+        # i64
+        elif opcode is BinaryOpcode.I64_ADD:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_SUB:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_MUL:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_DIV_S:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_DIV_U:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_REM_S:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_REM_U:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_AND:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_OR:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_XOR:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_SHL:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_SHR_S:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_SHR_U:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_ROTL:
+            return cls(opcode, ValType.i64)
+        elif opcode is BinaryOpcode.I64_ROTR:
+            return cls(opcode, ValType.i64)
+        # f32
+        elif opcode is BinaryOpcode.F32_ADD:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_SUB:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_MUL:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_DIV:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_MIN:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_MAX:
+            return cls(opcode, ValType.f32)
+        elif opcode is BinaryOpcode.F32_COPYSIGN:
+            return cls(opcode, ValType.f32)
+        # f64
+        elif opcode is BinaryOpcode.F64_ADD:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_SUB:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_MUL:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_DIV:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_MIN:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_MAX:
+            return cls(opcode, ValType.f64)
+        elif opcode is BinaryOpcode.F64_COPYSIGN:
+            return cls(opcode, ValType.f64)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class TestOp(Interned):
+    def __init__(self, opcode: BinaryOpcode, valtype: ValType) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'TestOp':
+        if opcode is BinaryOpcode.I32_EQZ:
+            return cls(opcode, ValType.i32)
+        elif opcode is BinaryOpcode.I64_EQZ:
+            return cls(opcode, ValType.i64)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class Wrap(SimpleOp):
+    opcode = BinaryOpcode.I32_WRAP_I64
+    valtype = ValType.i32
+    result = ValType.i64
+
+
+@register
+class Truncate(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType,
+                 result: ValType,
+                 signed: bool) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+        self.result = result
+        self.signed = signed
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'Truncate':
+        if opcode is BinaryOpcode.I32_TRUNC_S_F32:
+            return cls(opcode, ValType.i32, ValType.f32, True)
+        elif opcode is BinaryOpcode.I32_TRUNC_U_F32:
+            return cls(opcode, ValType.i32, ValType.f32, False)
+        elif opcode is BinaryOpcode.I32_TRUNC_S_F64:
+            return cls(opcode, ValType.i32, ValType.f64, True)
+        elif opcode is BinaryOpcode.I32_TRUNC_U_F64:
+            return cls(opcode, ValType.i32, ValType.f64, False)
+        elif opcode is BinaryOpcode.I64_TRUNC_S_F32:
+            return cls(opcode, ValType.i64, ValType.f32, True)
+        elif opcode is BinaryOpcode.I64_TRUNC_U_F32:
+            return cls(opcode, ValType.i64, ValType.f32, False)
+        elif opcode is BinaryOpcode.I64_TRUNC_S_F64:
+            return cls(opcode, ValType.i64, ValType.f64, True)
+        elif opcode is BinaryOpcode.I64_TRUNC_U_F64:
+            return cls(opcode, ValType.i64, ValType.f64, False)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class Extend(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType,
+                 result: ValType,
+                 signed: bool) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+        self.result = result
+        self.signed = signed
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'Extend':
+        if opcode is BinaryOpcode.I64_EXTEND_S_I32:
+            return cls(opcode, ValType.i64, ValType.i32, True)
+        elif opcode is BinaryOpcode.I64_EXTEND_U_I32:
+            return cls(opcode, ValType.i64, ValType.i32, False)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class Demote(SimpleOp):
+    opcode = BinaryOpcode.F32_DEMOTE_F64
+    valtype = ValType.f32
+    result = ValType.f64
+
+
+@register
+class Promote(SimpleOp):
+    opcode = BinaryOpcode.F64_PROMOTE_F32
+    valtype = ValType.f64
+    result = ValType.f32
+
+
+@register
+class Convert(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType,
+                 result: ValType,
+                 signed: bool) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+        self.result = result
+        self.signed = signed
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'Convert':
+        if opcode is BinaryOpcode.F32_CONVERT_S_I32:
+            return cls(opcode, ValType.f32, ValType.i32, True)
+        elif opcode is BinaryOpcode.F32_CONVERT_U_I32:
+            return cls(opcode, ValType.f32, ValType.i32, False)
+        elif opcode is BinaryOpcode.F32_CONVERT_S_I64:
+            return cls(opcode, ValType.f32, ValType.i64, True)
+        elif opcode is BinaryOpcode.F32_CONVERT_U_I64:
+            return cls(opcode, ValType.f32, ValType.i64, False)
+        elif opcode is BinaryOpcode.F64_CONVERT_S_I32:
+            return cls(opcode, ValType.f64, ValType.i32, True)
+        elif opcode is BinaryOpcode.F64_CONVERT_U_I32:
+            return cls(opcode, ValType.f64, ValType.i32, False)
+        elif opcode is BinaryOpcode.F64_CONVERT_S_I64:
+            return cls(opcode, ValType.f64, ValType.i64, True)
+        elif opcode is BinaryOpcode.F64_CONVERT_U_I64:
+            return cls(opcode, ValType.f64, ValType.i64, False)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+@register
+class Reinterpret(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 valtype: ValType,
+                 result: ValType) -> None:
+        self.opcode = opcode
+        self.valtype = valtype
+        self.result = result
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls, opcode: BinaryOpcode) -> 'Reinterpret':
+        if opcode is BinaryOpcode.I32_REINTERPRET_F32:
+            return cls(opcode, ValType.i32, ValType.f32)
+        elif opcode is BinaryOpcode.I64_REINTERPRET_F64:
+            return cls(opcode, ValType.i64, ValType.f64)
+        elif opcode is BinaryOpcode.F32_REINTERPRET_I32:
+            return cls(opcode, ValType.f32, ValType.i32)
+        elif opcode is BinaryOpcode.F64_REINTERPRET_I64:
+            return cls(opcode, ValType.f64, ValType.i64)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")

--- a/wasm/instructions/parametric.py
+++ b/wasm/instructions/parametric.py
@@ -1,0 +1,18 @@
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .base import (
+    SimpleOp,
+    register,
+)
+
+
+@register
+class Drop(SimpleOp):
+    opcode = BinaryOpcode.DROP
+
+
+@register
+class Select(SimpleOp):
+    opcode = BinaryOpcode.SELECT

--- a/wasm/instructions/variable.py
+++ b/wasm/instructions/variable.py
@@ -1,0 +1,80 @@
+import enum
+
+from wasm._utils.interned import (
+    Interned,
+)
+from wasm.datatypes import (
+    GlobalIdx,
+    LocalIdx,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .base import (
+    register,
+)
+
+
+@register
+class LocalAction(enum.Enum):
+    get = 0x20
+    set = 0x21
+    tee = 0x22
+
+
+@register
+class LocalOp(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 action: LocalAction,
+                 local_idx: LocalIdx) -> None:
+        self.opcode = opcode
+        self.action = action
+        self.local_idx = local_idx
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    local_idx: LocalIdx) -> 'LocalOp':
+        if opcode is BinaryOpcode.GET_LOCAL:
+            return cls(opcode, LocalAction.get, local_idx)
+        elif opcode is BinaryOpcode.SET_LOCAL:
+            return cls(opcode, LocalAction.set, local_idx)
+        elif opcode is BinaryOpcode.TEE_LOCAL:
+            return cls(opcode, LocalAction.tee, local_idx)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")
+
+
+class GlobalAction(enum.Enum):
+    get = 0x23
+    set = 0x24
+
+
+@register
+class GlobalOp(Interned):
+    def __init__(self,
+                 opcode: BinaryOpcode,
+                 action: GlobalAction,
+                 global_idx: GlobalIdx) -> None:
+        self.opcode = opcode
+        self.action = action
+        self.global_idx = global_idx
+
+    def __str__(self) -> str:
+        return self.opcode.text
+
+    @classmethod
+    def from_opcode(cls,
+                    opcode: BinaryOpcode,
+                    global_idx: GlobalIdx) -> 'GlobalOp':
+        if opcode is BinaryOpcode.GET_GLOBAL:
+            return cls(opcode, GlobalAction.get, global_idx)
+        elif opcode is BinaryOpcode.SET_GLOBAL:
+            return cls(opcode, GlobalAction.set, global_idx)
+        else:
+            raise Exception(f"Invariant: got unknown opcode {opcode}")

--- a/wasm/opcodes/binary.py
+++ b/wasm/opcodes/binary.py
@@ -46,6 +46,14 @@ class BinaryOpcode(enum.Enum):
     def is_variable(self) -> bool:
         return 0x20 <= self.value <= 0x24
 
+    @property
+    def is_local(self) -> bool:
+        return 0x20 <= self.value <= 0x22
+
+    @property
+    def is_global(self) -> bool:
+        return self is self.GET_GLOBAL or self is self.SET_GLOBAL
+
     #
     # Memory: 5.4.5
     #

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -1,0 +1,180 @@
+import io
+from typing import (
+    Iterable,
+    Tuple,
+    cast,
+)
+
+from wasm._utils.toolz import (
+    partitionby,
+)
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Call,
+    CallIndirect,
+    Else,
+    End,
+    If,
+    Instruction,
+    Loop,
+    Nop,
+    Return,
+    Unreachable,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+from wasm.typing import (
+    UInt8,
+)
+
+from .indices import (
+    parse_funcidx,
+    parse_labelidx,
+    parse_typeidx,
+)
+from .null import (
+    parse_null_byte,
+)
+from .vector import (
+    parse_vector,
+)
+
+
+def parse_control_instruction(opcode: BinaryOpcode,
+                              stream: io.BytesIO) -> Instruction:
+    if opcode is BinaryOpcode.UNREACHABLE:
+        return Unreachable()
+    elif opcode is BinaryOpcode.NOP:
+        return Nop()
+    elif opcode is BinaryOpcode.BLOCK:
+        return parse_block_instruction(stream)
+    elif opcode is BinaryOpcode.LOOP:
+        return parse_loop_instruction(stream)
+    elif opcode is BinaryOpcode.IF:
+        return parse_if_instruction(stream)
+    elif opcode is BinaryOpcode.BR:
+        return parse_br_instruction(stream)
+    elif opcode is BinaryOpcode.BR_IF:
+        return parse_br_if_instruction(stream)
+    elif opcode is BinaryOpcode.BR_TABLE:
+        return parse_br_table_instruction(stream)
+    elif opcode is BinaryOpcode.RETURN:
+        return Return()
+    elif opcode is BinaryOpcode.CALL:
+        return parse_call_instruction(stream)
+    elif opcode is BinaryOpcode.CALL_INDIRECT:
+        return parse_call_indirect_instruction(stream)
+    elif opcode is BinaryOpcode.END:
+        return End()
+    elif opcode is BinaryOpcode.ELSE:
+        return Else()
+    else:
+        raise Exception(f"Unhandled: {opcode}")
+
+
+def parse_block_valtype(stream: io.BytesIO) -> Tuple[ValType, ...]:
+    raw_byte = stream.read(1)
+
+    if not raw_byte:
+        raise Exception("TODO: end of stream")
+
+    raw_value = UInt8(raw_byte[0])
+
+    if raw_value == 0x40:
+        return tuple()
+
+    try:
+        return (ValType.from_byte(raw_value),)
+    except ValueError as err:
+        raise Exception(f"TODO: parse error: invalid valtype: {err}")
+
+
+def parse_block_instruction(stream: io.BytesIO) -> Block:
+    result_type = parse_block_valtype(stream)
+    instructions = parse_inner_block_instructions(stream)
+
+    return Block(result_type, instructions)
+
+
+def parse_inner_block_instructions(stream: io.BytesIO) -> Tuple[BaseInstruction, ...]:
+    return tuple(_parse_inner_block_instructions(stream))
+
+
+def _parse_inner_block_instructions(stream: io.BytesIO) -> Iterable[BaseInstruction]:
+    # recursive parsing
+    from wasm.parsers.instructions import parse_instruction  # noqa: F401
+
+    while True:
+        instruction = cast(BaseInstruction, parse_instruction(stream))
+        yield instruction
+        if isinstance(instruction, End):
+            break
+
+
+def parse_loop_instruction(stream: io.BytesIO) -> Loop:
+    result_type = parse_block_valtype(stream)
+    instructions = parse_inner_block_instructions(stream)
+
+    return Loop(result_type, instructions)
+
+
+def parse_if_instruction(stream: io.BytesIO) -> If:
+    result_type = parse_block_valtype(stream)
+
+    all_instructions = parse_inner_block_instructions(stream)
+    partitioned_instructions = tuple(partitionby(lambda v: isinstance(v, Else), all_instructions))
+
+    if len(partitioned_instructions) == 1:  # if without else
+        if_instructions = all_instructions
+        instructions = if_instructions[:-1] + Else.as_tail()
+        else_instructions = End.as_tail()
+    elif len(partitioned_instructions) == 2:  # empty if clause
+        instructions, else_instructions = partitioned_instructions
+    elif len(partitioned_instructions) == 3:
+        if_instructions, _, else_instructions = partitioned_instructions
+        instructions = if_instructions + Else.as_tail()
+    else:
+        raise Exception("TODO: if block contained more than one else clause")
+
+    return If(
+        result_type,
+        instructions,
+        else_instructions,
+    )
+
+
+def parse_br_instruction(stream: io.BytesIO) -> Br:
+    label = parse_labelidx(stream)
+    return Br(label)
+
+
+def parse_br_if_instruction(stream: io.BytesIO) -> BrIf:
+    label = parse_labelidx(stream)
+    return BrIf(label)
+
+
+def parse_br_table_instruction(stream: io.BytesIO) -> BrTable:
+    labels = parse_vector(parse_labelidx, stream)
+    default_label = parse_labelidx(stream)
+
+    return BrTable(labels, default_label)
+
+
+def parse_call_instruction(stream: io.BytesIO) -> Call:
+    func_idx = parse_funcidx(stream)
+    return Call(func_idx)
+
+
+def parse_call_indirect_instruction(stream: io.BytesIO) -> CallIndirect:
+    type_idx = parse_typeidx(stream)
+    parse_null_byte(stream)
+
+    return CallIndirect(type_idx)

--- a/wasm/parsers/indices.py
+++ b/wasm/parsers/indices.py
@@ -1,0 +1,38 @@
+import io
+
+from wasm.datatypes import (
+    FuncIdx,
+    GlobalIdx,
+    LabelIdx,
+    LocalIdx,
+    TypeIdx,
+)
+
+from .integers import (
+    parse_u32,
+)
+
+
+def parse_funcidx(stream: io.BytesIO) -> FuncIdx:
+    raw_idx = parse_u32(stream)
+    return FuncIdx(raw_idx)
+
+
+def parse_globalidx(stream: io.BytesIO) -> GlobalIdx:
+    raw_idx = parse_u32(stream)
+    return GlobalIdx(raw_idx)
+
+
+def parse_labelidx(stream: io.BytesIO) -> LabelIdx:
+    raw_idx = parse_u32(stream)
+    return LabelIdx(raw_idx)
+
+
+def parse_localidx(stream: io.BytesIO) -> LocalIdx:
+    raw_idx = parse_u32(stream)
+    return LocalIdx(raw_idx)
+
+
+def parse_typeidx(stream: io.BytesIO) -> TypeIdx:
+    raw_idx = parse_u32(stream)
+    return TypeIdx(raw_idx)

--- a/wasm/parsers/instructions.py
+++ b/wasm/parsers/instructions.py
@@ -1,0 +1,56 @@
+import io
+
+from wasm.exceptions import (
+    MalformedModule,
+)
+from wasm.instructions import (
+    Instruction,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .control import (
+    parse_control_instruction,
+)
+from .memory import (
+    parse_memory_instruction,
+)
+from .numeric import (
+    parse_numeric_instruction,
+)
+from .parametric import (
+    parse_parametric_instruction,
+)
+from .variable import (
+    parse_variable_instruction,
+)
+
+
+def parse_instruction(stream: io.BytesIO) -> Instruction:
+    opcode_byte = stream.read(1)
+
+    try:
+        opcode_value = opcode_byte[0]
+    except IndexError:
+        raise Exception("TODO: end of stream, what is the right exception here")
+
+    try:
+        opcode = BinaryOpcode(opcode_value)
+    except ValueError:
+        raise MalformedModule(
+            f"Unknown opcode: {hex(opcode_value)} found at position {stream.tell() - 1}"
+        )
+
+    if opcode.is_numeric:
+        return parse_numeric_instruction(opcode, stream)
+    elif opcode.is_variable:
+        return parse_variable_instruction(opcode, stream)
+    elif opcode.is_memory:
+        return parse_memory_instruction(opcode, stream)
+    elif opcode.is_parametric:
+        return parse_parametric_instruction(opcode, stream)
+    elif opcode.is_control:
+        return parse_control_instruction(opcode, stream)
+    else:
+        raise Exception(f"Unhandled opcode: {opcode}")

--- a/wasm/parsers/memory.py
+++ b/wasm/parsers/memory.py
@@ -1,0 +1,41 @@
+import io
+
+from wasm.instructions import (
+    Instruction,
+    MemoryArg,
+    MemoryGrow,
+    MemoryOp,
+    MemorySize,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .integers import (
+    parse_u32,
+)
+from .null import (
+    parse_null_byte,
+)
+
+
+def parse_memory_instruction(opcode: BinaryOpcode,
+                             stream: io.BytesIO) -> Instruction:
+    if opcode.is_memory_access:
+        memarg = parse_memarg(stream)
+
+        return MemoryOp.from_opcode(opcode, memarg)
+    elif opcode is BinaryOpcode.MEMORY_SIZE:
+        parse_null_byte(stream)
+        return MemorySize()
+    elif opcode is BinaryOpcode.MEMORY_GROW:
+        parse_null_byte(stream)
+        return MemoryGrow()
+    else:
+        raise Exception("Invariant")
+
+
+def parse_memarg(stream: io.BytesIO) -> MemoryArg:
+    align = parse_u32(stream)
+    offset = parse_u32(stream)
+    return MemoryArg(offset, align)

--- a/wasm/parsers/null.py
+++ b/wasm/parsers/null.py
@@ -1,0 +1,15 @@
+import io
+
+from wasm.exceptions import (
+    MalformedModule,
+)
+
+
+def parse_null_byte(stream: io.BytesIO) -> None:
+    byte = stream.read(1)
+    if byte == b'\x00':
+        return
+    elif byte:
+        raise MalformedModule(f"TODO: expected 0x00 but got {hex(byte[0])}")
+    else:
+        raise Exception("Unexpected end of stream")

--- a/wasm/parsers/numeric.py
+++ b/wasm/parsers/numeric.py
@@ -1,0 +1,83 @@
+import io
+
+from wasm.instructions import (
+    BinOp,
+    Convert,
+    Demote,
+    Extend,
+    F32Const,
+    F64Const,
+    I32Const,
+    I64Const,
+    Instruction,
+    Promote,
+    Reinterpret,
+    RelOp,
+    TestOp,
+    Truncate,
+    UnOp,
+    Wrap,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .floats import (
+    parse_f32,
+    parse_f64,
+)
+from .integers import (
+    parse_i32,
+    parse_i64,
+)
+
+
+def parse_numeric_instruction(opcode: BinaryOpcode,
+                              stream: io.BytesIO) -> Instruction:
+    if opcode.is_numeric_constant:
+        return parse_numeric_constant_instruction(opcode, stream)
+    elif opcode.is_relop:
+        return RelOp.from_opcode(opcode)
+    elif opcode.is_unop:
+        return UnOp.from_opcode(opcode)
+    elif opcode.is_binop:
+        return BinOp.from_opcode(opcode)
+    elif opcode.is_testop:
+        return TestOp.from_opcode(opcode)
+    elif opcode.is_conversion:
+        return parse_conversion_instruction(opcode)
+    else:
+        raise Exception(f"Unhandled opcode: {opcode}")
+
+
+def parse_numeric_constant_instruction(opcode: BinaryOpcode,
+                                       stream: io.BytesIO) -> Instruction:
+    if opcode is BinaryOpcode.I32_CONST:
+        return I32Const.from_opcode(opcode, parse_i32(stream))
+    elif opcode is BinaryOpcode.I64_CONST:
+        return I64Const.from_opcode(opcode, parse_i64(stream))
+    elif opcode is BinaryOpcode.F32_CONST:
+        return F32Const.from_opcode(opcode, parse_f32(stream))
+    elif opcode is BinaryOpcode.F64_CONST:
+        return F64Const.from_opcode(opcode, parse_f64(stream))
+    else:
+        raise Exception("Invariant")
+
+
+def parse_conversion_instruction(opcode: BinaryOpcode) -> Instruction:
+    if opcode is BinaryOpcode.I32_WRAP_I64:
+        return Wrap()
+    elif opcode in {BinaryOpcode.I64_EXTEND_S_I32, BinaryOpcode.I64_EXTEND_U_I32}:
+        return Extend.from_opcode(opcode)
+    elif opcode.is_truncate:
+        return Truncate.from_opcode(opcode)
+    elif opcode.is_convert:
+        return Convert.from_opcode(opcode)
+    elif opcode is BinaryOpcode.F64_PROMOTE_F32:
+        return Promote()
+    elif opcode is BinaryOpcode.F32_DEMOTE_F64:
+        return Demote()
+    elif opcode.is_reinterpret:
+        return Reinterpret.from_opcode(opcode)
+    else:
+        raise Exception(f"Invariant: unknown conversion opcode: {opcode}")

--- a/wasm/parsers/parametric.py
+++ b/wasm/parsers/parametric.py
@@ -1,0 +1,20 @@
+import io
+
+from wasm.instructions import (
+    Drop,
+    Instruction,
+    Select,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+
+def parse_parametric_instruction(opcode: BinaryOpcode,
+                                 stream: io.BytesIO) -> Instruction:
+    if opcode is BinaryOpcode.DROP:
+        return Drop()
+    elif opcode is BinaryOpcode.SELECT:
+        return Select()
+    else:
+        raise Exception(f"Invariant: got unknown opcode {opcode}")

--- a/wasm/parsers/variable.py
+++ b/wasm/parsers/variable.py
@@ -1,0 +1,27 @@
+import io
+
+from wasm.instructions import (
+    GlobalOp,
+    Instruction,
+    LocalOp,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .indices import (
+    parse_globalidx,
+    parse_localidx,
+)
+
+
+def parse_variable_instruction(opcode: BinaryOpcode,
+                               stream: io.BytesIO) -> Instruction:
+    if opcode.is_local:
+        local_idx = parse_localidx(stream)
+        return LocalOp.from_opcode(opcode, local_idx)
+    elif opcode.is_global:
+        global_idx = parse_globalidx(stream)
+        return GlobalOp.from_opcode(opcode, global_idx)
+    else:
+        raise Exception(f"Invariant: got unknown opcode {opcode}")

--- a/wasm/parsers/vector.py
+++ b/wasm/parsers/vector.py
@@ -1,0 +1,35 @@
+import io
+from typing import (
+    Callable,
+    Iterable,
+    Tuple,
+    TypeVar,
+)
+
+from wasm.typing import (
+    UInt32,
+)
+
+from .integers import (
+    parse_u32,
+)
+
+TItem = TypeVar('TItem')
+
+
+def parse_vector(sub_parser: Callable[[io.BytesIO], TItem],
+                 stream: io.BytesIO,
+                 ) -> Tuple[TItem, ...]:
+    vector_size = parse_u32(stream)
+    try:
+        return tuple(_parse_vector(sub_parser, vector_size, stream))
+    except Exception as err:
+        raise Exception(f"TODO: error parsing vector items: {err}")
+
+
+def _parse_vector(sub_parser: Callable[[io.BytesIO], TItem],
+                  vector_size: UInt32,
+                  stream: io.BytesIO,
+                  ) -> Iterable[TItem]:
+    for _ in range(vector_size):
+        yield sub_parser(stream)

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -3,10 +3,14 @@ from typing import (
     Any,
     Dict,
     NewType,
+    Tuple,
     Union,
 )
 
 if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        Instruction,
+    )
     from wasm.datatypes import (  # noqa: F401
         FuncIdx,
         FuncType,
@@ -23,6 +27,10 @@ if TYPE_CHECKING:
 Store = Dict[Any, Any]
 Module = Dict[Any, Any]
 Context = Dict[Any, Any]
+Config = Dict[Any, Any]
+
+
+Expression = Tuple["Instruction", ...]
 
 
 ExportDesc = Union[


### PR DESCRIPTION
### What was wrong

Parsing of raw wasm bytecode to an internal representation suitable for validation and execution was previous done with a large function body with many nested `if/elif/else` statements, resulting in instructions in the form of `["<opcode-text>", ...<args>]` where `<args>` were things like the parsed constant values for opcodes like `i32.const` or the list of nested instructions in the case of opcodes like `block`.

Subsequently, to do things like determining the argument types of an instructions, things like `typ = 1instr[0][:3]` would occur to infer the type from the text representation of the opcode.

### How was this fixed.

The parsing of the opcodes is now done with a single `parse_instruction` function which delegates to multiple sub-parsers.

The instructions themselves are now represented using formal classes which also implement strongly typed values for things like value types, whether the instruction is signed, etc.  This allows for `isinstance` checks or direct comparison against the `instruction.opcode` and the `Enum` of all opcodes.

![funny-pictures-surprised-animals-08](https://user-images.githubusercontent.com/824194/51858721-a0664e00-22f2-11e9-8bd7-6832984cea4a.jpg)