### PR TITLE
Add singleton class

### DIFF
--- a/tests/core/test_singleton_util.py
+++ b/tests/core/test_singleton_util.py
@@ -1,0 +1,51 @@
+from wasm._utils.singleton import (
+    Singleton,
+)
+
+
+def test_base_singleton_class():
+    inst_a = Singleton()
+    inst_b = Singleton()
+
+    assert inst_a is inst_b
+
+
+class SubA(Singleton):
+    pass
+
+
+class SubB(Singleton):
+    pass
+
+
+def test_subclassed_singletons():
+    base = Singleton()
+
+    inst_a1 = SubA()
+    inst_a2 = SubA()
+
+    inst_b1 = SubB()
+    inst_b2 = SubB()
+
+    assert inst_a1 is inst_a2
+    assert inst_b1 is inst_b2
+
+    assert base is not inst_a1
+    assert base is not inst_b1
+    assert inst_a1 is not inst_b1
+
+
+class WithArgs(Singleton):
+    def __init__(self, val_a, val_b):
+        self.val_a = val_a
+        self.val_b = val_b
+
+
+def test_singleton_class_with_initialization_args():
+    inst_a = WithArgs(1, val_b='2')
+    inst_b = WithArgs(1, val_b='2')
+
+    assert inst_a is inst_b
+
+    assert inst_a.val_a == 1
+    assert inst_a.val_b == '2'

--- a/wasm/_utils/singleton.py
+++ b/wasm/_utils/singleton.py
@@ -1,0 +1,16 @@
+from typing import (
+    Any,
+    Dict,
+    Type,
+)
+
+
+class Singleton:
+    _cache: Dict[Type['Singleton'], 'Singleton'] = {}
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> 'Singleton':
+        if cls not in cls._cache:
+            instance = super().__new__(cls)
+            instance.__init__(*args, **kwargs)
+            cls._cache[cls] = instance
+        return cls._cache[cls]


### PR DESCRIPTION
Extracted from #29 

## What was wrong?

Many of the opcodes are stateless meaning that we don't actually need to instantiate a new object for each occurrence of the opcode instruction.

## How was it fixed?

This implements a simple `Singleton` base class which keeps a reference to the first instance created for a given class and then always returns the same instance on subsequent instantiations.

#### Cute Animal Picture

![animals-also-get-surprised-028](https://user-images.githubusercontent.com/824194/51771470-525d0a80-20a6-11e9-92b5-c8993b25846a.jpg)

