### PR TITLE
Add bitsize enum

### DIFF
--- a/tests/core/val-type/test_val_type.py
+++ b/tests/core/val-type/test_val_type.py
@@ -3,6 +3,7 @@ import itertools
 import pytest
 
 from wasm.datatypes import (
+    BitSize,
     ValType,
 )
 
@@ -11,7 +12,7 @@ from wasm.datatypes import (
     'get_X_type,bit_size',
     itertools.product(
         [ValType.get_integer_type, ValType.get_float_type],
-        (0, 31, 33, 63, 65),
+        (0, 31, 33, 63, 65, BitSize.b8, BitSize.b16),
     ),
 )
 def test_get_X_type_invalid_bit_size(get_X_type, bit_size):
@@ -22,8 +23,8 @@ def test_get_X_type_invalid_bit_size(get_X_type, bit_size):
 @pytest.mark.parametrize(
     'value,expected',
     (
-        (32, ValType.f32),
-        (64, ValType.f64),
+        (BitSize.b32, ValType.f32),
+        (BitSize.b64, ValType.f64),
     )
 )
 def test_get_float_type(value, expected):
@@ -36,8 +37,8 @@ def test_get_float_type(value, expected):
 @pytest.mark.parametrize(
     'value,expected',
     (
-        (32, ValType.i32),
-        (64, ValType.i64),
+        (BitSize.b32, ValType.i32),
+        (BitSize.b64, ValType.i64),
     )
 )
 def test_get_integer_type(value, expected):
@@ -76,10 +77,10 @@ def test_is_integer_type(value, expected):
 @pytest.mark.parametrize(
     'value,expected',
     (
-        (ValType.f32, 32),
-        (ValType.f64, 64),
-        (ValType.i32, 32),
-        (ValType.i64, 64),
+        (ValType.f32, BitSize.b32),
+        (ValType.f64, BitSize.b64),
+        (ValType.i32, BitSize.b32),
+        (ValType.i64, BitSize.b64),
     ),
 )
 def test_get_bit_size(value, expected):

--- a/wasm/constants.py
+++ b/wasm/constants.py
@@ -1,10 +1,6 @@
 from .typing import (
-    BitSize,
     UInt32,
 )
-
-BITS32 = BitSize(32)
-BITS64 = BitSize(64)
 
 UINT6_CEIL = UInt32(2 ** 6)
 

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -1,3 +1,6 @@
+from .bit_size import (  # noqa: F401
+    BitSize,
+)
 from .exports import (  # noqa: F401
     Export,
 )

--- a/wasm/datatypes/bit_size.py
+++ b/wasm/datatypes/bit_size.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class BitSize(enum.Enum):
+    b8 = 8
+    b16 = 16
+    b32 = 32
+    b64 = 64

--- a/wasm/datatypes/indices.py
+++ b/wasm/datatypes/indices.py
@@ -6,6 +6,14 @@ class GlobalIdx(int):
     pass
 
 
+class LabelIdx(int):
+    pass
+
+
+class LocalIdx(int):
+    pass
+
+
 class MemoryIdx(int):
     pass
 

--- a/wasm/datatypes/val_type.py
+++ b/wasm/datatypes/val_type.py
@@ -1,11 +1,11 @@
 import enum
 
-from wasm import (
-    constants,
-)
 from wasm.typing import (
-    BitSize,
     UInt8,
+)
+
+from .bit_size import (
+    BitSize,
 )
 
 
@@ -26,7 +26,7 @@ class ValType(enum.Enum):
         elif byte == 0x7c:
             return cls.f64
         else:
-            raise KeyError(
+            raise ValueError(
                 "Provided byte does not map to a value type.  Got "
                 f"'{hex(byte)}'. Must be one of 0x7f|0x7e|0x7d|0x7c"
             )
@@ -64,21 +64,21 @@ class ValType(enum.Enum):
     @property
     def bit_size(self) -> BitSize:
         if self is self.i32:
-            return constants.BITS32
+            return BitSize.b32
         elif self is self.i64:
-            return constants.BITS64
+            return BitSize.b64
         elif self is self.f32:
-            return constants.BITS32
+            return BitSize.b32
         elif self is self.f64:
-            return constants.BITS64
+            return BitSize.b64
         else:
             raise Exception("Invariant")
 
     @classmethod
     def get_float_type(cls, num_bits: BitSize) -> 'ValType':
-        if num_bits == 32:
+        if num_bits is BitSize.b32:
             return cls.f32
-        elif num_bits == 64:
+        elif num_bits is BitSize.b64:
             return cls.f64
         else:
             raise ValueError(
@@ -87,9 +87,9 @@ class ValType(enum.Enum):
 
     @classmethod
     def get_integer_type(cls, num_bits: BitSize) -> 'ValType':
-        if num_bits == 32:
+        if num_bits == BitSize.b32:
             return cls.i32
-        elif num_bits == 64:
+        elif num_bits == BitSize.b64:
             return cls.i64
         else:
             raise ValueError(

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -51,5 +51,3 @@ ExternType = Union[
 
 UInt8 = NewType('UInt8', int)
 UInt32 = NewType('UInt32', int)
-
-BitSize = NewType('BitSize', int)


### PR DESCRIPTION
Extracted from #29 

## What was wrong?

Using an integer for bit size was less precise than desired.

## How was it fixed?

Updated to be an `Enum` for better constraints on the allowed values.

#### Cute Animal Picture

![surprised-animals-16](https://user-images.githubusercontent.com/824194/51772124-74578c80-20a8-11e9-8a27-d96fd302f6a6.jpg)

