### PR TITLE
Add tests for opcode completeness

### DIFF
--- a/tests/core/opcodes/test_all_binary_opcodes_have_text.py
+++ b/tests/core/opcodes/test_all_binary_opcodes_have_text.py
@@ -1,0 +1,24 @@
+import pytest
+
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+from wasm.opcodes.text import (
+    OPCODE_TO_TEXT,
+)
+
+
+@pytest.mark.parametrize(
+    'opcode',
+    tuple(iter(BinaryOpcode)),
+)
+def test_all_opcodes_have_text_representations(opcode):
+    assert opcode.text
+
+
+def test_no_extra_text_values_for_opcodes():
+    all_opcode_texts = set(opcode.text for opcode in BinaryOpcode)
+    all_raw_texts = set(OPCODE_TO_TEXT.values())
+
+    assert all_opcode_texts == all_raw_texts
+    assert len(all_opcode_texts) == len(BinaryOpcode)


### PR DESCRIPTION
## What was wrong?

As @carver pointed out in #30 we might want some assurances that our mapping from opcode to text values is complete.

## How was it fixed?

Added a test to enumerate the opcodes and verify they all have text values.

#### Cute Animal Picture

![im-a-professional-dog-photographer-58bf6868ce09b__880](https://user-images.githubusercontent.com/824194/51775240-4c6d2680-20b2-11e9-8c0f-7d3507b73639.jpg)

