### PR TITLE
Piper/implement integer and floating point parsers

### DIFF
--- a/tests/core/numeric-utils/test_signed_to_unsigned.py
+++ b/tests/core/numeric-utils/test_signed_to_unsigned.py
@@ -1,0 +1,57 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    s32_to_u32,
+    s64_to_u64,
+)
+
+
+@pytest.mark.parametrize(
+    'convert_fn,value,expected',
+    (
+        (s32_to_u32, 0, 0),
+        (s64_to_u64, 0, 0),
+        (s32_to_u32, 1, 1),
+        (s64_to_u64, 1, 1),
+        (s32_to_u32, constants.SINT32_MIN, constants.SINT32_CEIL),
+        (s64_to_u64, constants.SINT64_MIN, constants.SINT64_CEIL),
+    ),
+)
+def test_signed_to_unsigned(convert_fn, value, expected):
+    actual = convert_fn(value)
+    assert actual == expected
+
+
+@given(
+    value=st.integers(
+        min_value=constants.SINT32_MIN,
+        max_value=constants.SINT32_MAX,
+    ),
+)
+def test_signed32_to_unsigned32_fuzz(value):
+    actual = s32_to_u32(value)
+    if value >= 0:
+        assert actual == value
+    else:
+        assert actual >= 0
+
+
+@given(
+    value=st.integers(
+        min_value=constants.SINT64_MIN,
+        max_value=constants.SINT64_MAX,
+    ),
+)
+def test_signed64_to_unsigned64_fuzz(value):
+    actual = s64_to_u64(value)
+    if value >= 0:
+        assert actual == value
+    else:
+        assert actual >= 0

--- a/tests/core/parsers/test_floating_point_parsers.py
+++ b/tests/core/parsers/test_floating_point_parsers.py
@@ -1,0 +1,62 @@
+import io
+import math
+import struct
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from wasm.parsers.floats import (
+    parse_f32,
+    parse_f64,
+)
+
+
+@pytest.mark.parametrize(
+    'encoded,expected',
+    (
+        # from a spec test failure while refactoring the library.
+        (b'\x00\x00\xc0\x7f', math.nan),
+    ),
+)
+def test_parse_f32(encoded, expected):
+    actual = parse_f32(io.BytesIO(encoded))
+
+    if math.isnan(expected):
+        assert math.isnan(actual)
+    elif math.isinf(expected):
+        assert math.isinf(actual)
+    else:
+        assert actual == expected
+
+
+@given(
+    value=st.floats(width=32),
+)
+def test_parse_f32_fuzz(value):
+    encoded = struct.pack('<f', value)
+    result = parse_f32(io.BytesIO(encoded))
+
+    if math.isnan(value):
+        assert math.isnan(result)
+    elif math.isinf(value):
+        assert math.isinf(result)
+    else:
+        assert result == value
+
+
+@given(
+    value=st.floats(width=64),
+)
+def test_parse_f64_fuzz(value):
+    encoded = struct.pack('<d', value)
+    result = parse_f64(io.BytesIO(encoded))
+
+    if math.isnan(value):
+        assert math.isnan(result)
+    elif math.isinf(value):
+        assert math.isinf(result)
+    else:
+        assert result == value

--- a/tests/core/parsers/test_integer_parsers.py
+++ b/tests/core/parsers/test_integer_parsers.py
@@ -1,0 +1,71 @@
+import io
+
+import pytest
+
+from wasm.exceptions import (
+    MalformedModule,
+)
+from wasm.parsers.integers import (
+    parse_i32,
+    parse_i64,
+    parse_s32,
+    parse_s64,
+    parse_u32,
+    parse_u64,
+)
+
+
+@pytest.mark.parametrize(
+    'parse_fn,raw_value',
+    (
+        (parse_i32, b'\x80\x80\x80\x80\x80\x00'),
+        (parse_s32, b'\x80\x80\x80\x80\x80\x00'),
+        (parse_u32, b'\x80\x80\x80\x80\x80\x00'),
+        (parse_i64, b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x00'),
+        (parse_s64, b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x00'),
+        (parse_u64, b'\x80\x80\x80\x80\x80\x80\x80\x80\x80\x80\x00'),
+    ),
+)
+def test_values_exceeding_byte_width(parse_fn, raw_value):
+    with pytest.raises(MalformedModule, match="maximum byte width"):
+        parse_fn(io.BytesIO(raw_value))
+
+
+@pytest.mark.parametrize(
+    'parse_fn,raw_value',
+    (
+        (parse_i32, b'\xff\xff\xff\xff\x0f'),
+        (parse_s32, b'\xff\xff\xff\xff\x0f'),
+        (parse_i64, b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x0f'),
+        (parse_s64, b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\x0f'),
+    ),
+)
+def test_out_of_range_value(parse_fn, raw_value):
+    with pytest.raises(MalformedModule, match="decoded .* is greater than"):
+        parse_fn(io.BytesIO(raw_value))
+
+
+@pytest.mark.parametrize(
+    'parse_fn,raw_value,expected',
+    (
+        (parse_i32, b'\x00', 0),
+        (parse_s32, b'\x00', 0),
+        (parse_u32, b'\x00', 0),
+        (parse_i64, b'\x00', 0),
+        (parse_s64, b'\x00', 0),
+        (parse_u64, b'\x00', 0),
+        # from wikipedia spec (unsigned)
+        (parse_i32, b'\xe5\x8e\x26', 624485),
+        (parse_s32, b'\xe5\x8e\x26', 624485),
+        (parse_u32, b'\xe5\x8e\x26', 624485),
+        (parse_i64, b'\xe5\x8e\x26', 624485),
+        (parse_s64, b'\xe5\x8e\x26', 624485),
+        (parse_u64, b'\xe5\x8e\x26', 624485),
+        # from wikipedia spec (signed)
+        (parse_s32, b'\x9b\xf1\x59', -624485),
+        (parse_s64, b'\x9b\xf1\x59', -624485),
+    ),
+)
+def test_parseing_encoded_integer(parse_fn, raw_value, expected):
+    actual = parse_fn(io.BytesIO(raw_value))
+    assert actual == expected

--- a/tests/core/parsers/test_leb128_parsers.py
+++ b/tests/core/parsers/test_leb128_parsers.py
@@ -1,0 +1,32 @@
+import io
+
+import pytest
+
+from wasm.parsers.leb128 import (
+    parse_signed_leb128,
+    parse_unsigned_leb128,
+)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (b'\x00', 0),
+        (b'\xe5\x8e\x26', 624485),
+    ),
+)
+def test_parse_unsigned_leb128(value, expected):
+    actual = parse_unsigned_leb128(io.BytesIO(value))
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (b'\x00', 0),
+        (b'\x9b\xf1\x59', -624485),
+    ),
+)
+def test_parse_signed_leb128(value, expected):
+    actual = parse_signed_leb128(io.BytesIO(value))
+    assert actual == expected

--- a/wasm/_utils/numeric.py
+++ b/wasm/_utils/numeric.py
@@ -1,0 +1,23 @@
+from wasm import (
+    constants,
+)
+from wasm.typing import (
+    SInt32,
+    SInt64,
+    UInt32,
+    UInt64,
+)
+
+
+def s32_to_u32(value: SInt32) -> UInt32:
+    if value < 0:
+        return UInt32(value + constants.UINT32_CEIL)
+    else:
+        return UInt32(value)
+
+
+def s64_to_u64(value: SInt64) -> UInt64:
+    if value < 0:
+        return UInt64(value + constants.UINT64_CEIL)
+    else:
+        return UInt64(value)

--- a/wasm/constants.py
+++ b/wasm/constants.py
@@ -1,5 +1,8 @@
 from .typing import (
+    SInt32,
+    SInt64,
     UInt32,
+    UInt64,
 )
 
 UINT6_CEIL = UInt32(2 ** 6)
@@ -13,6 +16,17 @@ UINT16_MAX = UInt32(2 ** 16 - 1)
 
 UINT32_CEIL = 2 ** 32
 UINT32_MAX = UInt32(2 ** 32 - 1)
+
+UINT64_CEIL = 2 ** 64
+UINT64_MAX = UInt64(2 ** 64 - 1)
+
+SINT32_CEIL = 2 ** 31
+SINT32_MAX = SInt32(2 ** 31 - 1)
+SINT32_MIN = SInt32(-1 * 2 ** 31)
+
+SINT64_CEIL = 2 ** 63
+SINT64_MAX = SInt64(2 ** 63 - 1)
+SINT64_MIN = SInt64(-1 * 2 ** 63)
 
 INT32_NEGATIVE_ONE = UINT32_MAX
 

--- a/wasm/parsers/floats.py
+++ b/wasm/parsers/floats.py
@@ -1,0 +1,30 @@
+import io
+import struct
+from typing import (
+    cast,
+)
+
+from wasm.typing import (
+    Float32,
+    Float64,
+)
+
+
+def parse_f32(stream: io.BytesIO) -> Float32:
+    raw_buffer = stream.read(4)
+    buffer = bytes(reversed(raw_buffer))
+    if len(buffer) < 4:
+        raise Exception("TODO: better exception for insufficient bytes")
+
+    value = struct.unpack(">f", buffer)[0]
+    return cast(Float32, value)
+
+
+def parse_f64(stream: io.BytesIO) -> Float64:
+    raw_buffer = stream.read(8)
+    buffer = bytes(reversed(raw_buffer))
+    if len(buffer) < 8:
+        raise Exception("TODO: better exception for insufficient bytes")
+
+    value = struct.unpack(">d", buffer)[0]
+    return cast(Float64, value)

--- a/wasm/parsers/integers.py
+++ b/wasm/parsers/integers.py
@@ -1,0 +1,135 @@
+import io
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    s32_to_u32,
+    s64_to_u64,
+)
+from wasm.exceptions import (
+    MalformedModule,
+)
+from wasm.typing import (
+    SInt32,
+    SInt64,
+    UInt32,
+    UInt64,
+)
+
+from .leb128 import (
+    parse_signed_leb128,
+    parse_unsigned_leb128,
+)
+
+
+def parse_s32(stream: io.BytesIO) -> SInt32:
+    start_pos = stream.tell()
+    value = parse_signed_leb128(stream)
+    end_pos = stream.tell()
+
+    byte_width = end_pos - start_pos
+
+    if byte_width > 5:  # ceil(32 / 7)
+        raise MalformedModule(
+            f"encoded s32 exceeds maximum byte width: {byte_width} > 10"
+        )
+    elif constants.SINT32_MIN <= value < constants.SINT32_CEIL:
+        return SInt32(value)
+    elif value < constants.SINT32_MIN:
+        raise MalformedModule(
+            f"decoded s32 is less than SINT32_MIN: {value} < -1 * 2**31"
+        )
+    elif value > constants.SINT32_MAX:
+        raise MalformedModule(
+            f"decoded s32 is greater than SINT32_MAX: {value} > 2**31 - 1"
+        )
+    else:
+        raise Exception("Invariant")
+
+
+def parse_s64(stream: io.BytesIO) -> SInt64:
+    start_pos = stream.tell()
+    value = parse_signed_leb128(stream)
+    end_pos = stream.tell()
+
+    byte_width = end_pos - start_pos
+
+    if byte_width > 10:  # ceil(64 / 7)
+        raise MalformedModule(
+            f"encoded s64 exceeds maximum byte width: {byte_width} > 10"
+        )
+    elif constants.SINT64_MIN <= value < constants.SINT64_CEIL:
+        return SInt64(value)
+    elif value < constants.SINT64_MIN:
+        raise MalformedModule(
+            f"decoded s64 is less than SINT64_MIN: {value} < -1 * 2**63"
+        )
+    elif value > constants.SINT64_MAX:
+        raise MalformedModule(
+            f"decoded s64 is greater than SINT64_MAX: {value} > 2**63 - 1"
+        )
+    else:
+        raise Exception("Invariant")
+
+
+def parse_u32(stream: io.BytesIO) -> UInt32:
+    start_pos = stream.tell()
+    value = parse_unsigned_leb128(stream)
+    end_pos = stream.tell()
+
+    byte_width = end_pos - start_pos
+
+    if byte_width > 5:  # ceil(32 / 7)
+        raise MalformedModule(
+            f"encoded u32 exceeds maximum byte width: {byte_width} > 10"
+        )
+    elif 0 <= value < constants.UINT32_CEIL:
+        return UInt32(value)
+    elif value < 0:
+        raise MalformedModule(
+            f"decoded uin32 was not positive: {value}"
+        )
+    elif value > constants.UINT32_MAX:
+        raise MalformedModule(
+            f"decoded uin32 is greater than UINT32_MAX: {value} > 2**32 - 1"
+        )
+    else:
+        raise Exception("Invariant")
+
+
+def parse_u64(stream: io.BytesIO) -> UInt64:
+    start_pos = stream.tell()
+    value = parse_unsigned_leb128(stream)
+    end_pos = stream.tell()
+
+    byte_width = end_pos - start_pos
+
+    if byte_width > 10:  # ceil(64 / 7)
+        raise MalformedModule(
+            f"encoded u64 exceeds maximum byte width: {byte_width} > 10"
+        )
+    elif 0 <= value < constants.UINT64_CEIL:
+        return UInt64(value)
+    elif value < 0:
+        raise MalformedModule(
+            f"decoded u64 was not positive: {value}"
+        )
+    elif value > constants.UINT64_MAX:
+        raise MalformedModule(
+            f"decoded u64 is greater than UINT64_MAX: {value} > 2**64 - 1"
+        )
+    else:
+        raise Exception("Invariant")
+
+
+def parse_i32(stream: io.BytesIO) -> UInt32:
+    value_s = parse_s32(stream)
+    value = s32_to_u32(value_s)
+    return value
+
+
+def parse_i64(stream: io.BytesIO) -> UInt64:
+    value_s = parse_s64(stream)
+    value = s64_to_u64(value_s)
+    return value

--- a/wasm/parsers/leb128.py
+++ b/wasm/parsers/leb128.py
@@ -1,0 +1,69 @@
+import functools
+import io
+import itertools
+import math
+import operator
+from typing import (
+    Iterable,
+)
+
+SIGN_MASK = 2**6
+REMOVE_SIGN_MASK = 2**6 - 1
+
+
+def parse_signed_leb128(stream: io.BytesIO) -> int:
+    """
+    https://en.wikipedia.org/wiki/LEB128
+    """
+    parts = tuple(_parse_unsigned_leb128(stream))
+    part_with_sign = parts[-1]
+    shift = 7 * (len(parts) - 1)
+    sign = (part_with_sign >> shift) & SIGN_MASK
+    part_without_sign = ((part_with_sign >> shift) & REMOVE_SIGN_MASK) << shift
+    value = functools.reduce(
+        operator.or_,
+        itertools.chain(parts[:-1], (part_without_sign,)),
+        0,
+    )
+    if sign:
+        return value - 2 ** (7 * len(parts) - 1)
+    else:
+        return value
+
+
+LOW_MASK = 2**7 - 1
+HIGH_MASK = 2**7
+
+
+def parse_unsigned_leb128(stream: io.BytesIO) -> int:
+    """
+    https://en.wikipedia.org/wiki/LEB128
+    """
+    return functools.reduce(
+        operator.or_,
+        _parse_unsigned_leb128(stream),
+        0,
+    )
+
+
+# The maximum shift width for a 64 bit integer.  We shouldn't have to decode
+# integers larger than this.
+SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
+
+
+def _parse_unsigned_leb128(stream: io.BytesIO) -> Iterable[int]:
+    for shift in itertools.count(0, 7):
+        if shift > SHIFT_64_BIT_MAX:
+            raise Exception("TODO: better exception msg: Integer is too large...")
+
+        byte = stream.read(1)
+
+        try:
+            value = byte[0]
+        except IndexError:
+            raise Exception("TODO: proper error message for empty stream")
+
+        yield (value & LOW_MASK) << shift
+
+        if not value & HIGH_MASK:
+            break

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -51,3 +51,8 @@ ExternType = Union[
 
 UInt8 = NewType('UInt8', int)
 UInt32 = NewType('UInt32', int)
+UInt64 = NewType('UInt64', int)
+
+
+SInt32 = NewType('SInt32', int)
+SInt64 = NewType('SInt64', int)

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -56,3 +56,7 @@ UInt64 = NewType('UInt64', int)
 
 SInt32 = NewType('SInt32', int)
 SInt64 = NewType('SInt64', int)
+
+
+Float32 = NewType('Float32', float)
+Float64 = NewType('Float64', float)


### PR DESCRIPTION
Builds on #34 

## What was wrong?

The current way the bytecode is parsed is error prone, with each parser function returning the parsed value and the updated index in the bytecode where the next parser should continue from.  In this model it is very easy to end up in situations where you do things like resuming parsing from the wrong location.

## How was it fixed?

Implement parsers that operate on a readable/seekable stream, currently just using `io.BytesIO` but eventually opening this up to any file-like object.

These parsers implement integer and floating point number parsing.

#### Cute Animal Picture

![proxy duckduckgo com](https://user-images.githubusercontent.com/824194/51776252-b0ddb500-20b5-11e9-8d82-c99cad503db9.gif)

