### PR TITLE
Remove foot gun from singleton class

### DIFF
--- a/tests/core/test_singleton_util.py
+++ b/tests/core/test_singleton_util.py
@@ -1,3 +1,5 @@
+import pytest
+
 from wasm._utils.singleton import (
     Singleton,
 )
@@ -42,10 +44,11 @@ class WithArgs(Singleton):
 
 
 def test_singleton_class_with_initialization_args():
-    inst_a = WithArgs(1, val_b='2')
-    inst_b = WithArgs(1, val_b='2')
+    with pytest.raises(TypeError, match="does not allow arguments"):
+        WithArgs(1, 2)
 
-    assert inst_a is inst_b
+    with pytest.raises(TypeError, match="does not allow arguments"):
+        WithArgs(1, val_b=2)
 
-    assert inst_a.val_a == 1
-    assert inst_a.val_b == '2'
+    with pytest.raises(TypeError, match="does not allow arguments"):
+        WithArgs(val_a=1, val_b=2)

--- a/wasm/_utils/singleton.py
+++ b/wasm/_utils/singleton.py
@@ -11,6 +11,7 @@ class Singleton:
     def __new__(cls, *args: Any, **kwargs: Any) -> 'Singleton':
         if cls not in cls._cache:
             instance = super().__new__(cls)
-            instance.__init__(*args, **kwargs)
+            if args or kwargs:
+                raise TypeError("Singleton does not allow arguments")
             cls._cache[cls] = instance
         return cls._cache[cls]


### PR DESCRIPTION
From: https://github.com/ethereum/py-wasm/pull/31#pullrequestreview-196743579

## What was wrong?

The `Singleton` class had a :mans_shoe: :gun:  (foot gun)

## How was it fixed?

Disallow any arguments for singleton classes.

#### Cute Animal Picture

![cute-animals-image-a-mouse-in-flowers-this-is-for-you-the-other-quite-surprised](https://user-images.githubusercontent.com/824194/51777379-10d65a80-20ba-11e9-8e5e-3da2d0c7e6f9.jpg)

