### PR TITLE
Implement module type

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -13,8 +13,10 @@ from .exports import (  # noqa: F401
 from .function import (  # noqa: F401
     Function,
     FunctionType,
+    StartFunction,
 )
 from .globals import (  # noqa: F401
+    Global,
     GlobalType,
 )
 from .imports import (  # noqa: F401
@@ -33,13 +35,18 @@ from .limits import (  # noqa: F401
     Limits,
 )
 from .memory import (  # noqa: F401
+    Memory,
     MemoryType,
+)
+from .module import (  # noqa: F401
+    Module,
 )
 from .mutability import (  # noqa: F401
     Mutability,
 )
 from .table import (  # noqa: F401
     FuncRef,
+    Table,
     TableType,
 )
 from .val_type import (  # noqa: F401

--- a/wasm/datatypes/data_segment.py
+++ b/wasm/datatypes/data_segment.py
@@ -1,17 +1,20 @@
 from typing import (
+    TYPE_CHECKING,
     NamedTuple,
-)
-
-from wasm.typing import (
-    Expression,
+    Tuple,
 )
 
 from .indices import (
     MemoryIdx,
 )
 
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        BaseInstruction,
+    )
+
 
 class DataSegment(NamedTuple):
     mem_idx: MemoryIdx
-    offset: Expression
+    offset: Tuple['BaseInstruction', ...]
     init: bytes

--- a/wasm/datatypes/element_segment.py
+++ b/wasm/datatypes/element_segment.py
@@ -1,10 +1,7 @@
 from typing import (
+    TYPE_CHECKING,
     NamedTuple,
     Tuple,
-)
-
-from wasm.typing import (
-    Expression,
 )
 
 from .indices import (
@@ -12,8 +9,13 @@ from .indices import (
     TableIdx,
 )
 
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        BaseInstruction,
+    )
+
 
 class ElementSegment(NamedTuple):
     table_idx: TableIdx
-    offset: Expression
+    offset: Tuple['BaseInstruction', ...]
     init: Tuple[FuncIdx, ]

--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -1,9 +1,6 @@
 from typing import (
     NamedTuple,
-)
-
-from wasm.typing import (
-    ExportDesc,
+    Union,
 )
 
 from .indices import (
@@ -19,20 +16,48 @@ class Export(NamedTuple):
     https://webassembly.github.io/spec/core/bikeshed/index.html#memory-types%E2%91%A0
     """
     name: str
-    desc: ExportDesc
+    desc: Union[FuncIdx, GlobalIdx, MemoryIdx, TableIdx]
 
     @property
     def is_function(self):
         return isinstance(self.desc, FuncIdx)
 
     @property
+    def func_idx(self) -> FuncIdx:
+        if isinstance(self.desc, FuncIdx):
+            return self.desc
+        else:
+            raise TypeError(f"Export descriptor of type: {type(self.desc)}")
+
+    @property
     def is_global(self):
         return isinstance(self.desc, GlobalIdx)
+
+    @property
+    def global_idx(self) -> GlobalIdx:
+        if isinstance(self.desc, GlobalIdx):
+            return self.desc
+        else:
+            raise TypeError(f"Export descriptor of type: {type(self.desc)}")
 
     @property
     def is_memory(self):
         return isinstance(self.desc, MemoryIdx)
 
     @property
+    def memory_idx(self) -> MemoryIdx:
+        if isinstance(self.desc, MemoryIdx):
+            return self.desc
+        else:
+            raise TypeError(f"Export descriptor of type: {type(self.desc)}")
+
+    @property
     def is_table(self):
         return isinstance(self.desc, TableIdx)
+
+    @property
+    def table_idx(self) -> TableIdx:
+        if isinstance(self.desc, TableIdx):
+            return self.desc
+        else:
+            raise TypeError(f"Export descriptor of type: {type(self.desc)}")

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -4,11 +4,8 @@ from typing import (
     Tuple,
 )
 
-from wasm.typing import (
-    Expression,
-)
-
 from .indices import (
+    FuncIdx,
     TypeIdx,
 )
 from .val_type import (
@@ -17,7 +14,7 @@ from .val_type import (
 
 if TYPE_CHECKING:
     from wasm.instructions import (  # noqa: F401
-        Instruction,
+        BaseInstruction,
     )
 
 
@@ -35,4 +32,11 @@ class Function(NamedTuple):
     """
     type: TypeIdx
     locals: Tuple[ValType, ...]
-    body: Expression
+    body: Tuple['BaseInstruction', ...]
+
+
+class StartFunction(NamedTuple):
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#syntax-start
+    """
+    func_idx: FuncIdx

--- a/wasm/datatypes/globals.py
+++ b/wasm/datatypes/globals.py
@@ -1,5 +1,7 @@
 from typing import (
+    TYPE_CHECKING,
     NamedTuple,
+    Tuple,
 )
 
 from .mutability import (
@@ -9,6 +11,11 @@ from .val_type import (
     ValType,
 )
 
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        BaseInstruction,
+    )
+
 
 class GlobalType(NamedTuple):
     """
@@ -16,3 +23,8 @@ class GlobalType(NamedTuple):
     """
     mut: Mutability
     valtype: ValType
+
+
+class Global(NamedTuple):
+    type: GlobalType
+    init: Tuple['BaseInstruction', ...]

--- a/wasm/datatypes/imports.py
+++ b/wasm/datatypes/imports.py
@@ -1,9 +1,6 @@
 from typing import (
     NamedTuple,
-)
-
-from wasm.typing import (
-    ImportDesc,
+    Union,
 )
 
 from .globals import (
@@ -23,7 +20,14 @@ from .table import (
 class Import(NamedTuple):
     module: str
     name: str
-    desc: ImportDesc
+    desc: Union[TypeIdx, GlobalType, MemoryType, TableType]
+
+    @property
+    def type_idx(self) -> TypeIdx:
+        if isinstance(self.desc, TypeIdx):
+            return self.desc
+        else:
+            raise TypeError(f"Import descriptor of type: {type(self.desc)}")
 
     @property
     def is_function(self):

--- a/wasm/datatypes/memory.py
+++ b/wasm/datatypes/memory.py
@@ -14,3 +14,7 @@ class MemoryType(NamedTuple):
     """
     min: UInt32
     max: Optional[UInt32]
+
+
+class Memory(NamedTuple):
+    type: MemoryType

--- a/wasm/datatypes/module.py
+++ b/wasm/datatypes/module.py
@@ -1,0 +1,45 @@
+from typing import (
+    NamedTuple,
+    Optional,
+    Tuple,
+)
+
+from .data_segment import (
+    DataSegment,
+)
+from .element_segment import (
+    ElementSegment,
+)
+from .exports import (
+    Export,
+)
+from .function import (
+    Function,
+    FunctionType,
+    StartFunction,
+)
+from .globals import (
+    Global,
+)
+from .imports import (
+    Import,
+)
+from .memory import (
+    Memory,
+)
+from .table import (
+    Table,
+)
+
+
+class Module(NamedTuple):
+    types: Tuple[FunctionType, ...]
+    funcs: Tuple[Function, ...]
+    tables: Tuple[Table, ...]
+    mems: Tuple[Memory, ...]
+    globals: Tuple[Global, ...]
+    elem: Tuple[ElementSegment, ...]
+    data: Tuple[DataSegment, ...]
+    start: Optional[StartFunction]
+    imports: Tuple[Import, ...]
+    exports: Tuple[Export, ...]

--- a/wasm/datatypes/table.py
+++ b/wasm/datatypes/table.py
@@ -21,3 +21,7 @@ class TableType(NamedTuple):
     """
     limits: Limits
     elem_type: Type[FuncRef]
+
+
+class Table(NamedTuple):
+    type: TableType

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -73,7 +73,7 @@ def instantiate_module_from_wasm_file(
 
         # imports preparation
         externvalstar: List[Any] = []
-        for import_ in module["imports"]:
+        for import_ in module.imports:
             if import_.module not in registered_modules:
                 raise Unlinkable(f"Unlinkable module: {import_.module}")
 
@@ -164,10 +164,9 @@ def run_opcode_action_invoke(action, store, module, all_modules, registered_modu
 
 
 def run_opcode_action_get(action, store, module, all_modules, registered_modules):
-    exports = module["exports"]
     # this is naive, since test["expected"] is a list, should iterate over each
     # one, but maybe OK since there is only one test["action"]
-    for export in exports:
+    for export in module["exports"]:
         if export.name == action.field:
             globaladdr = export.desc
             value = store["globals"][globaladdr]["value"][1]

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -1,60 +1,11 @@
 from typing import (
-    TYPE_CHECKING,
     Any,
     Dict,
     NewType,
-    Tuple,
-    Union,
 )
 
-if TYPE_CHECKING:
-    from wasm.instructions import (  # noqa: F401
-        Instruction,
-    )
-    from wasm.datatypes import (  # noqa: F401
-        FuncIdx,
-        FunctionType,
-        GlobalIdx,
-        GlobalType,
-        MemoryIdx,
-        MemoryType,
-        TableIdx,
-        TableType,
-        TypeIdx,
-    )
-
-
 Store = Dict[Any, Any]
-Module = Dict[Any, Any]
-Context = Dict[Any, Any]
 Config = Dict[Any, Any]
-
-
-Expression = Tuple["Instruction", ...]
-
-
-ExportDesc = Union[
-    'FuncIdx',
-    'GlobalIdx',
-    'MemoryIdx',
-    'TableIdx',
-]
-
-
-ImportDesc = Union[
-    'TypeIdx',
-    'TableType',
-    'MemoryType',
-    'GlobalType',
-]
-
-
-ExternType = Union[
-    'FunctionType',
-    'TableType',
-    'MemoryType',
-    'GlobalType',
-]
 
 
 UInt8 = NewType('UInt8', int)


### PR DESCRIPTION
## What was wrong?

The WebAssembly spec defines a module type.  This value was represented using an untyped (unstructured) dictionary.  Similarly, the spec defines formal types for globals (not global type or global instance), memory, function, and table.  Each of these was also imprecisely represented using a dictionary.

## How was it fixed?

Created concrete data types for each of these structures.

This PR also eliminates a few values from `wasm.typing` that were resulting in the type checker complaining about recursive types.

#### Cute Animal Picture

![bf357c47c5b68471cbeff3352ca1dbdf](https://user-images.githubusercontent.com/824194/51873072-e9c99400-2318-11e9-9d80-7c11a7fa10bf.jpg)

