### PR TITLE
Formal data type for module/function/table/memory/global instance types

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -1,3 +1,9 @@
+from .addresses import (  # noqa: F401
+    FunctionAddress,
+    GlobalAddress,
+    MemoryAddress,
+    TableAddress,
+)
 from .bit_size import (  # noqa: F401
     BitSize,
 )
@@ -9,14 +15,18 @@ from .element_segment import (  # noqa: F401
 )
 from .exports import (  # noqa: F401
     Export,
+    ExportInstance,
 )
 from .function import (  # noqa: F401
+    BaseFunctionInstance,
     Function,
     FunctionType,
+    HostFunction,
     StartFunction,
 )
 from .globals import (  # noqa: F401
     Global,
+    GlobalInstance,
     GlobalType,
 )
 from .imports import (  # noqa: F401
@@ -36,19 +46,25 @@ from .limits import (  # noqa: F401
 )
 from .memory import (  # noqa: F401
     Memory,
+    MemoryInstance,
     MemoryType,
 )
 from .module import (  # noqa: F401
+    FunctionInstance,
     Module,
+    ModuleInstance,
 )
 from .mutability import (  # noqa: F401
     Mutability,
 )
 from .table import (  # noqa: F401
-    FuncRef,
     Table,
+    TableInstance,
     TableType,
 )
 from .val_type import (  # noqa: F401
     ValType,
 )
+
+
+BaseFunctionInstance.register(FunctionInstance)

--- a/wasm/datatypes/addresses.py
+++ b/wasm/datatypes/addresses.py
@@ -1,0 +1,14 @@
+class FunctionAddress(int):
+    pass
+
+
+class TableAddress(int):
+    pass
+
+
+class MemoryAddress(int):
+    pass
+
+
+class GlobalAddress(int):
+    pass

--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -3,6 +3,12 @@ from typing import (
     Union,
 )
 
+from .addresses import (
+    FunctionAddress,
+    GlobalAddress,
+    MemoryAddress,
+    TableAddress,
+)
 from .indices import (
     FuncIdx,
     GlobalIdx,
@@ -61,3 +67,24 @@ class Export(NamedTuple):
             return self.desc
         else:
             raise TypeError(f"Export descriptor of type: {type(self.desc)}")
+
+
+class ExportInstance(NamedTuple):
+    name: str
+    value: Union[FunctionAddress, TableAddress, MemoryAddress, GlobalAddress]
+
+    @property
+    def is_function(self):
+        return isinstance(self.value, FunctionAddress)
+
+    @property
+    def is_global(self):
+        return isinstance(self.value, GlobalAddress)
+
+    @property
+    def is_memory(self):
+        return isinstance(self.value, MemoryAddress)
+
+    @property
+    def is_table(self):
+        return isinstance(self.value, TableAddress)

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from typing import (
     TYPE_CHECKING,
     NamedTuple,
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
     from wasm.instructions import (  # noqa: F401
         BaseInstruction,
     )
+    from wasm.typing import (  # noqa: F401
+        HostFunctionCallable,
+    )
 
 
 class FunctionType(NamedTuple):
@@ -33,6 +37,15 @@ class Function(NamedTuple):
     type: TypeIdx
     locals: Tuple[ValType, ...]
     body: Tuple['BaseInstruction', ...]
+
+
+class BaseFunctionInstance(ABC):
+    type: FunctionType
+
+
+class HostFunction(NamedTuple):
+    type: FunctionType
+    hostcode: 'HostFunctionCallable'
 
 
 class StartFunction(NamedTuple):

--- a/wasm/datatypes/globals.py
+++ b/wasm/datatypes/globals.py
@@ -12,6 +12,9 @@ from .val_type import (
 )
 
 if TYPE_CHECKING:
+    from wasm.typing import (  # noqa: F401
+        TValue,
+    )
     from wasm.instructions import (  # noqa: F401
         BaseInstruction,
     )
@@ -28,3 +31,11 @@ class GlobalType(NamedTuple):
 class Global(NamedTuple):
     type: GlobalType
     init: Tuple['BaseInstruction', ...]
+
+
+class GlobalInstance(NamedTuple):
+    # The `valtype` is not part of the spec, but it is useful for inspection.
+    valtype: ValType
+
+    value: 'TValue'
+    mut: Mutability

--- a/wasm/datatypes/memory.py
+++ b/wasm/datatypes/memory.py
@@ -18,3 +18,8 @@ class MemoryType(NamedTuple):
 
 class Memory(NamedTuple):
     type: MemoryType
+
+
+class MemoryInstance(NamedTuple):
+    data: bytearray
+    max: Optional[UInt32]

--- a/wasm/datatypes/module.py
+++ b/wasm/datatypes/module.py
@@ -4,6 +4,12 @@ from typing import (
     Tuple,
 )
 
+from .addresses import (
+    FunctionAddress,
+    GlobalAddress,
+    MemoryAddress,
+    TableAddress,
+)
 from .data_segment import (
     DataSegment,
 )
@@ -12,6 +18,7 @@ from .element_segment import (
 )
 from .exports import (
     Export,
+    ExportInstance,
 )
 from .function import (
     Function,
@@ -43,3 +50,23 @@ class Module(NamedTuple):
     start: Optional[StartFunction]
     imports: Tuple[Import, ...]
     exports: Tuple[Export, ...]
+
+
+class ModuleInstance(NamedTuple):
+    types: Tuple[FunctionType, ...]
+    func_addrs: Tuple[FunctionAddress, ...]
+    table_addrs: Tuple[TableAddress, ...]
+    memory_addrs: Tuple[MemoryAddress, ...]
+    global_addrs: Tuple[GlobalAddress, ...]
+    exports: Tuple[ExportInstance, ...]
+
+
+# This class is located here to prevent `mypy` from complaining about recursive
+# types until they are supported.
+# https://github.com/python/mypy/issues/731
+class FunctionInstance(NamedTuple):
+    """
+    """
+    type: FunctionType
+    module: ModuleInstance
+    code: Function

--- a/wasm/datatypes/table.py
+++ b/wasm/datatypes/table.py
@@ -1,18 +1,20 @@
 from typing import (
+    List,
     NamedTuple,
+    Optional,
     Type,
 )
 
+from wasm.typing import (
+    UInt32,
+)
+
+from .addresses import (
+    FunctionAddress,
+)
 from .limits import (
     Limits,
 )
-
-
-class FuncRef(NamedTuple):
-    """
-    Stub data type for function references
-    """
-    pass
 
 
 class TableType(NamedTuple):
@@ -20,8 +22,13 @@ class TableType(NamedTuple):
     https://webassembly.github.io/spec/core/bikeshed/index.html#table-types%E2%91%A0
     """
     limits: Limits
-    elem_type: Type[FuncRef]
+    elem_type: Type[FunctionAddress]
 
 
 class Table(NamedTuple):
     type: TableType
+
+
+class TableInstance(NamedTuple):
+    elem: List[Optional[FunctionAddress]]
+    max: Optional[UInt32]

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -2,23 +2,27 @@ import logging
 
 import wasm
 from wasm.datatypes import (
-    Export,
-    FuncIdx,
-    FuncRef,
+    ExportInstance,
+    FunctionAddress,
     FunctionType,
-    GlobalIdx,
+    GlobalAddress,
     GlobalType,
     Limits,
-    MemoryIdx,
+    MemoryAddress,
     MemoryType,
+    ModuleInstance,
     Mutability,
-    TableIdx,
+    TableAddress,
     TableType,
     ValType,
 )
+from wasm.typing import (
+    Store,
+    UInt32,
+)
 
 
-def instantiate_spectest_module(store):
+def instantiate_spectest_module(store: Store) -> ModuleInstance:
     logger = logging.getLogger("wasm.tools.fixtures.modules.spectest")
 
     def spectest__print_i32(store, arg):
@@ -58,7 +62,7 @@ def instantiate_spectest_module(store):
     wasm.alloc_func(store, FunctionType((), ()), spectest__print)
 
     # min:1,max:2 required by import.wast:
-    wasm.alloc_mem(store, MemoryType(1, 2))
+    wasm.alloc_mem(store, MemoryType(UInt32(1), UInt32(2)))
 
     # 666 required by import.wast
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.i32), 666)
@@ -66,10 +70,10 @@ def instantiate_spectest_module(store):
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.f32), 0.0)
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.f64), 0.0)
     wasm.alloc_table(
-        store, TableType(Limits(10, 20), FuncRef)
+        store, TableType(Limits(UInt32(10), UInt32(20)), FunctionAddress)
     )  # max was 30, changed to 20 for import.wast
-    moduleinst = {
-        "types": [
+    moduleinst = ModuleInstance(
+        types=(
             FunctionType((ValType.i32,), ()),
             FunctionType((ValType.i64,), ()),
             FunctionType((ValType.f32,), ()),
@@ -77,26 +81,26 @@ def instantiate_spectest_module(store):
             FunctionType((ValType.i32, ValType.f32), ()),
             FunctionType((ValType.f64, ValType.f64), ()),
             FunctionType((), ()),
-        ],
-        "funcaddrs": [FuncIdx(idx) for idx in range(7)],
-        "tableaddrs": [TableIdx(0)],
-        "memaddrs": [MemoryIdx(0)],
-        "globaladdrs": [GlobalIdx(0), GlobalIdx(1)],
-        "exports": [
-            Export("print_i32", FuncIdx(0)),
-            Export("print_i64", FuncIdx(1)),
-            Export("print_f32", FuncIdx(2)),
-            Export("print_f64", FuncIdx(3)),
-            Export("print_i32_f32", FuncIdx(4)),
-            Export("print_f64_f64", FuncIdx(5)),
-            Export("print", FuncIdx(6)),
-            Export("memory", MemoryIdx(0)),
-            Export("global_i32", GlobalIdx(0)),
-            Export("global_f32", GlobalIdx(1)),
-            Export("global_f64", GlobalIdx(2)),
-            Export("table", TableIdx(0)),
-        ],
-    }
+        ),
+        func_addrs=tuple(FunctionAddress(idx) for idx in range(7)),
+        table_addrs=(TableAddress(0),),
+        memory_addrs=(MemoryAddress(0),),
+        global_addrs=(GlobalAddress(0), GlobalAddress(1)),
+        exports=(
+            ExportInstance("print_i32", FunctionAddress(0)),
+            ExportInstance("print_i64", FunctionAddress(1)),
+            ExportInstance("print_f32", FunctionAddress(2)),
+            ExportInstance("print_f64", FunctionAddress(3)),
+            ExportInstance("print_i32_f32", FunctionAddress(4)),
+            ExportInstance("print_f64_f64", FunctionAddress(5)),
+            ExportInstance("print", FunctionAddress(6)),
+            ExportInstance("memory", MemoryAddress(0)),
+            ExportInstance("global_i32", GlobalAddress(0)),
+            ExportInstance("global_f32", GlobalAddress(1)),
+            ExportInstance("global_f64", GlobalAddress(2)),
+            ExportInstance("table", TableAddress(0)),
+        ),
+    )
     return moduleinst
 
 
@@ -133,9 +137,9 @@ def instantiate_test_module(store):
     wasm.alloc_mem(store, MemoryType(1, None))
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.i32), 666)
     wasm.alloc_global(store, GlobalType(Mutability.const, ValType.f32), 0.0)
-    wasm.alloc_table(store, TableType(Limits(10, None), FuncRef))
-    moduleinst = {
-        "types": [
+    wasm.alloc_table(store, TableType(Limits(10, None), FunctionAddress))
+    moduleinst = ModuleInstance(
+        types=(
             FunctionType((), ()),
             FunctionType((ValType.i32,), ()),
             FunctionType((ValType.f32,), ()),
@@ -143,23 +147,23 @@ def instantiate_test_module(store):
             FunctionType((), (ValType.f32,)),
             FunctionType((ValType.i32,), (ValType.i32,)),
             FunctionType((ValType.i64,), (ValType.i64,)),
-        ],
-        "funcaddrs": [FuncIdx(idx) for idx in range(7)],
-        "tableaddrs": [TableIdx(0)],
-        "memaddrs": [MemoryIdx(0)],
-        "globaladdrs": [GlobalIdx(0), GlobalIdx(1)],
-        "exports": [
-            Export("func", FuncIdx(0)),
-            Export("func_i32", FuncIdx(1)),
-            Export("func_f32", FuncIdx(2)),
-            Export("func__i32", FuncIdx(3)),
-            Export("func__f32", FuncIdx(4)),
-            Export("func__i32_i32", FuncIdx(5)),
-            Export("func__i64_i64", FuncIdx(6)),
-            Export("memory-2-inf", MemoryIdx(0)),
-            Export("global-i32", GlobalIdx(0)),
-            Export("global-f32", GlobalIdx(1)),
-            Export("table-10-inf", TableIdx(0)),
-        ],
-    }
+        ),
+        func_addrs=tuple(FunctionAddress(idx) for idx in range(7)),
+        table_addrs=(TableAddress(0),),
+        memory_addrs=(MemoryAddress(0),),
+        global_addrs=(GlobalAddress(0), GlobalAddress(1)),
+        exports=(
+            ExportInstance("func", FunctionAddress(0)),
+            ExportInstance("func_i32", FunctionAddress(1)),
+            ExportInstance("func_f32", FunctionAddress(2)),
+            ExportInstance("func__i32", FunctionAddress(3)),
+            ExportInstance("func__f32", FunctionAddress(4)),
+            ExportInstance("func__i32_i32", FunctionAddress(5)),
+            ExportInstance("func__i64_i64", FunctionAddress(6)),
+            ExportInstance("memory-2-inf", MemoryAddress(0)),
+            ExportInstance("global-i32", GlobalAddress(0)),
+            ExportInstance("global-f32", GlobalAddress(1)),
+            ExportInstance("table-10-inf", TableAddress(0)),
+        ),
+    )
     return moduleinst

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -1,11 +1,16 @@
 from typing import (
     Any,
+    Callable,
     Dict,
+    List,
     NewType,
+    Tuple,
+    Union,
 )
 
 Store = Dict[Any, Any]
 Config = Dict[Any, Any]
+HostFunctionCallable = Callable[[Store, List[Any]], Tuple[Store, Any]]
 
 
 UInt8 = NewType('UInt8', int)
@@ -19,3 +24,11 @@ SInt64 = NewType('SInt64', int)
 
 Float32 = NewType('Float32', float)
 Float64 = NewType('Float64', float)
+
+
+TValue = Union[
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+]


### PR DESCRIPTION
## What was wrong?

The WebAssembly spec defines a formal data type for Module instances:

https://webassembly.github.io/spec/core/bikeshed/index.html#module-instances%E2%91%A0

This type is currently represented using a mutable dictionary.

Within this class exist instance types for memory, table, globals, functions.  Each of these is also represented as a mutable dictionary.

## How was it fixed?

- Implemented the data structures using `NamedTuple` to achieve immutability
- Minor adjustment to the instantiation code to remove circular dependency between function-instance/module-instance/store.
- Implemented formal types for both normal function instances and hostcode function instances.
- implemented formal types for table/memory/global instances.

#### Cute Animal Picture

![cone-of-shame-alternatives](https://user-images.githubusercontent.com/824194/51943488-d7ae2b00-23d6-11e9-9ef1-a6cdaf716bc6.jpg)

