### PR TITLE
Formalize Configuration object and execution data structures

### DIFF
--- a/tests/core/test_base_stack_datatype.py
+++ b/tests/core/test_base_stack_datatype.py
@@ -1,0 +1,50 @@
+import pytest
+
+from wasm.datatypes.stack import (
+    BaseStack,
+)
+
+
+class StackForTesting(BaseStack[str]):
+    pass
+
+
+@pytest.fixture
+def stack():
+    return StackForTesting()
+
+
+def test_stack_pushing_and_popping(stack):
+    stack.push('a')
+    stack.push('b')
+    stack.push('c')
+    stack.push('d')
+    stack.push('e')
+
+    assert stack.pop() == 'e'
+    assert stack.pop() == 'd'
+    assert stack.pop() == 'c'
+    assert stack.pop() == 'b'
+    assert stack.pop() == 'a'
+
+
+def test_stack_pop2(stack):
+    stack.push('a')
+    stack.push('b')
+    stack.push('c')
+    stack.push('d')
+
+    assert stack.pop2() == ('d', 'c')
+    assert stack.pop2() == ('b', 'a')
+
+
+def test_stack_peek(stack):
+    stack.push('a')
+    assert stack.peek() == 'a'
+
+    stack.push('b')
+    assert stack.peek() == 'b'
+
+    stack.pop()
+
+    assert stack.peek() == 'a'

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -7,6 +7,9 @@ from .addresses import (  # noqa: F401
 from .bit_size import (  # noqa: F401
     BitSize,
 )
+from .configuration import (  # noqa: F401
+    Configuration,
+)
 from .data_segment import (  # noqa: F401
     DataSegment,
 )
@@ -41,6 +44,9 @@ from .indices import (  # noqa: F401
     TableIdx,
     TypeIdx,
 )
+from .instructions import (  # noqa: F401
+    InstructionSequence,
+)
 from .limits import (  # noqa: F401
     Limits,
 )
@@ -56,6 +62,13 @@ from .module import (  # noqa: F401
 )
 from .mutability import (  # noqa: F401
     Mutability,
+)
+from .stack import (  # noqa: F401
+    Frame,
+    FrameStack,
+    Label,
+    LabelStack,
+    ValueStack,
 )
 from .table import (  # noqa: F401
     Table,

--- a/wasm/datatypes/configuration.py
+++ b/wasm/datatypes/configuration.py
@@ -1,0 +1,62 @@
+from typing import (
+    NamedTuple,
+)
+
+from wasm.typing import (
+    Store,
+)
+
+from .instructions import (
+    InstructionSequence,
+)
+from .stack import (
+    Frame,
+    FrameStack,
+    Label,
+    LabelStack,
+    ValueStack,
+)
+
+
+class Configuration(NamedTuple):
+    store: Store
+    value_stack: ValueStack
+    label_stack: LabelStack
+    frame_stack: FrameStack
+
+    @property
+    def frame(self) -> Frame:
+        return self.frame_stack.peek()
+
+    @property
+    def has_active_frame(self):
+        return bool(self.frame_stack)
+
+    @property
+    def label(self) -> Label:
+        if self.has_active_frame and self.has_active_label:
+            return self.label_stack.peek()
+        else:
+            raise IndexError("No labels active for current frame")
+
+    @property
+    def has_active_label(self):
+        if not self.has_active_frame:
+            return False
+        elif not self.label_stack:
+            return False
+        else:
+            return self.label_stack.peek().frame_id == self.frame.id
+
+    @property
+    def instructions(self) -> InstructionSequence:
+        if self.has_active_label:
+            return self.label.instructions
+        elif len(self.frame_stack):
+            return self.frame_stack.peek().instructions
+        else:
+            raise ValueError("No active instructions")
+
+    @property
+    def is_executable(self) -> bool:
+        return self.has_active_frame

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -29,6 +29,12 @@ class FunctionType(NamedTuple):
     params: Tuple[ValType, ...]
     results: Tuple[ValType, ...]
 
+    def __str__(self) -> str:
+        return f"FunctionType(params={self.params}, results={self.results})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
 
 class Function(NamedTuple):
     """

--- a/wasm/datatypes/instructions.py
+++ b/wasm/datatypes/instructions.py
@@ -1,0 +1,69 @@
+from collections.abc import (
+    Sequence,
+)
+from typing import (
+    TYPE_CHECKING,
+    Iterator,
+    Tuple,
+    overload,
+)
+
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        BaseInstruction,
+    )
+
+
+class InstructionSequence(Sequence):
+    _instructions: Tuple['BaseInstruction', ...]
+
+    def __init__(self, instructions: Tuple['BaseInstruction', ...]) -> None:
+        self._instructions = instructions
+        self._idx = -1
+
+    def __str__(self) -> str:
+        return f"[{' > '.join((str(instr) for instr in self._instructions))}]"
+
+    def __repr__(self) -> str:
+        return f"InstructionSequence({str(self)})"
+
+    def __len__(self) -> int:
+        return len(self._instructions)
+
+    def __next__(self) -> 'BaseInstruction':
+        self._idx += 1
+        try:
+            return self._instructions[self._idx]
+        except IndexError:
+            raise StopIteration
+
+    def __iter__(self) -> Iterator['BaseInstruction']:
+        while self._idx < len(self._instructions) - 1:
+            yield next(self)
+
+    @overload
+    def __getitem__(self, idx: int) -> 'BaseInstruction':
+        pass
+
+    @overload  # noqa: 811
+    def __getitem__(self, s: slice) -> 'InstructionSequence':
+        pass
+
+    def __getitem__(self, item):  # noqa: F811
+        if isinstance(item, int):
+            return self._instructions[item]
+        elif isinstance(item, slice):
+            return type(self)(self._instructions[item])
+        else:
+            raise TypeError(f"Unsupported key type: {type(item)}")
+
+    @property
+    def pc(self) -> int:
+        return max(0, self._idx)
+
+    @property
+    def current(self) -> 'BaseInstruction':
+        return self[self.pc]
+
+    def seek(self, idx: int) -> None:
+        self._idx = idx - 1

--- a/wasm/datatypes/stack.py
+++ b/wasm/datatypes/stack.py
@@ -1,0 +1,86 @@
+from typing import (
+    Generic,
+    Iterable,
+    List,
+    NamedTuple,
+    Tuple,
+    TypeVar,
+)
+import uuid
+
+from wasm.typing import (
+    TValue,
+)
+
+from .indices import (
+    LabelIdx,
+)
+from .instructions import (
+    InstructionSequence,
+)
+from .module import (
+    ModuleInstance,
+)
+
+TStackItem = TypeVar('TStackItem')
+
+
+class BaseStack(Generic[TStackItem]):
+    _stack: List[TStackItem]
+
+    def __init__(self) -> None:
+        self._stack = []
+
+    def __len__(self) -> int:
+        return len(self._stack)
+
+    def __bool__(self) -> bool:
+        return bool(self._stack)
+
+    def __iter__(self) -> Iterable[TStackItem]:
+        return iter(self._stack)
+
+    def pop(self) -> TStackItem:
+        return self._stack.pop()
+
+    def pop2(self) -> Tuple[TStackItem, TStackItem]:
+        return self._stack.pop(), self._stack.pop()
+
+    def pop3(self) -> Tuple[TStackItem, TStackItem, TStackItem]:
+        return self._stack.pop(), self._stack.pop(), self._stack.pop()
+
+    def push(self, value: TStackItem) -> None:
+        self._stack.append(value)
+
+    def peek(self) -> TStackItem:
+        return self._stack[-1]
+
+
+class ValueStack(BaseStack[TValue]):
+    pass
+
+
+class Frame(NamedTuple):
+    id: uuid.UUID
+    module: ModuleInstance
+    locals: List[TValue]
+    instructions: InstructionSequence
+    arity: int
+    height: int
+
+
+class FrameStack(BaseStack[Frame]):
+    pass
+
+
+class Label(NamedTuple):
+    arity: int
+    height: int
+    instructions: InstructionSequence
+    is_loop: bool
+    frame_id: uuid.UUID
+
+
+class LabelStack(BaseStack[Label]):
+    def get_by_label_idx(self, key: LabelIdx) -> Label:
+        return self._stack[-1 * (key + 1)]

--- a/wasm/datatypes/val_type.py
+++ b/wasm/datatypes/val_type.py
@@ -15,6 +15,12 @@ class ValType(enum.Enum):
     f32 = 'f32'
     f64 = 'f64'
 
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return str(self)
+
     @classmethod
     def from_byte(cls, byte: UInt8) -> 'ValType':
         if byte == 0x7f:

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -6,7 +6,6 @@ from pathlib import (
 )
 from typing import (
     Any,
-    Dict,
     List,
 )
 
@@ -59,7 +58,7 @@ def instantiate_module_from_wasm_file(
         file_path: Path,
         store: Store,
         registered_modules: List[ModuleInstance, ]
-) -> Dict[Any, Any]:
+) -> ModuleInstance:
     logger.debug("Loading wasm module from file: %s", file_path.name)
 
     if file_path.suffix != ".wasm":
@@ -90,7 +89,7 @@ def instantiate_module_from_wasm_file(
                 raise Unlinkable("Unlinkable module: export name not found")
 
             externvalstar += [externval]
-        _, moduleinst, _ = wasm.instantiate_module(store, module, externvalstar)
+        _, moduleinst, _ = wasm.instantiate_module(store, module, tuple(externvalstar))
     return moduleinst
 
 

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -9,7 +9,6 @@ from typing import (
 )
 
 Store = Dict[Any, Any]
-Config = Dict[Any, Any]
 HostFunctionCallable = Callable[[Store, List[Any]], Tuple[Store, Any]]
 
 


### PR DESCRIPTION
## What was wrong?

The `config` object used for all execution by the wasm interpreter is just a mutable dictionary with multiple mutable lists that are manipulated.

## How was it fixed?

- Implemented a `Configuration` class which houses the three stacks (values, labels, frames) and the store.
- Instruction sequences are now housed in their respective frames and labels.
- A new `InstructionSequence` class for managing the state of the stream of instructions.  This has removed the need for the `"continuation"` fields in label and frame because the parent instruction sequences automatically keep track of their position.
- New `Stack` data structures with `push()` and `pop()` APIs.

> Note:  This PR noticeably decreased performance (tests take longer to execute).  I'm planning to address this later.

#### Cute Animal Picture

![e-collar-blog](https://user-images.githubusercontent.com/824194/52014527-0098f380-249d-11e9-9b64-c2e9563451ab.jpg)

