### PR TITLE
Implement formal datatype for store

### DIFF
--- a/tests/core/test_base_stack_datatype.py
+++ b/tests/core/test_base_stack_datatype.py
@@ -1,0 +1,50 @@
+import pytest
+
+from wasm.datatypes.stack import (
+    BaseStack,
+)
+
+
+class StackForTesting(BaseStack[str]):
+    pass
+
+
+@pytest.fixture
+def stack():
+    return StackForTesting()
+
+
+def test_stack_pushing_and_popping(stack):
+    stack.push('a')
+    stack.push('b')
+    stack.push('c')
+    stack.push('d')
+    stack.push('e')
+
+    assert stack.pop() == 'e'
+    assert stack.pop() == 'd'
+    assert stack.pop() == 'c'
+    assert stack.pop() == 'b'
+    assert stack.pop() == 'a'
+
+
+def test_stack_pop2(stack):
+    stack.push('a')
+    stack.push('b')
+    stack.push('c')
+    stack.push('d')
+
+    assert stack.pop2() == ('d', 'c')
+    assert stack.pop2() == ('b', 'a')
+
+
+def test_stack_peek(stack):
+    stack.push('a')
+    assert stack.peek() == 'a'
+
+    stack.push('b')
+    assert stack.peek() == 'b'
+
+    stack.pop()
+
+    assert stack.peek() == 'a'

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ use_parentheses=True
 
 [flake8]
 max-line-length= 100
-exclude= venv*,.tox,docs,build,wasm/main.py
+exclude= venv*,.tox,docs,build
 ignore=
 
 [testenv]

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -70,6 +70,9 @@ from .stack import (  # noqa: F401
     LabelStack,
     ValueStack,
 )
+from .store import (  # noqa: F401
+    Store,
+)
 from .table import (  # noqa: F401
     Table,
     TableInstance,

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -7,6 +7,9 @@ from .addresses import (  # noqa: F401
 from .bit_size import (  # noqa: F401
     BitSize,
 )
+from .configuration import (  # noqa: F401
+    Configuration,
+)
 from .data_segment import (  # noqa: F401
     DataSegment,
 )
@@ -41,6 +44,9 @@ from .indices import (  # noqa: F401
     TableIdx,
     TypeIdx,
 )
+from .instructions import (  # noqa: F401
+    InstructionSequence,
+)
 from .limits import (  # noqa: F401
     Limits,
 )
@@ -56,6 +62,13 @@ from .module import (  # noqa: F401
 )
 from .mutability import (  # noqa: F401
     Mutability,
+)
+from .stack import (  # noqa: F401
+    Frame,
+    FrameStack,
+    Label,
+    LabelStack,
+    ValueStack,
 )
 from .table import (  # noqa: F401
     Table,

--- a/wasm/datatypes/configuration.py
+++ b/wasm/datatypes/configuration.py
@@ -1,0 +1,62 @@
+from typing import (
+    NamedTuple,
+)
+
+from wasm.typing import (
+    Store,
+)
+
+from .instructions import (
+    InstructionSequence,
+)
+from .stack import (
+    Frame,
+    FrameStack,
+    Label,
+    LabelStack,
+    ValueStack,
+)
+
+
+class Configuration(NamedTuple):
+    store: Store
+    value_stack: ValueStack
+    label_stack: LabelStack
+    frame_stack: FrameStack
+
+    @property
+    def frame(self) -> Frame:
+        return self.frame_stack.peek()
+
+    @property
+    def has_active_frame(self):
+        return bool(self.frame_stack)
+
+    @property
+    def label(self) -> Label:
+        if self.has_active_frame and self.has_active_label:
+            return self.label_stack.peek()
+        else:
+            raise IndexError("No labels active for current frame")
+
+    @property
+    def has_active_label(self):
+        if not self.has_active_frame:
+            return False
+        elif not self.label_stack:
+            return False
+        else:
+            return self.label_stack.peek().frame_id == self.frame.id
+
+    @property
+    def instructions(self) -> InstructionSequence:
+        if self.has_active_label:
+            return self.label.instructions
+        elif len(self.frame_stack):
+            return self.frame_stack.peek().instructions
+        else:
+            raise ValueError("No active instructions")
+
+    @property
+    def is_executable(self) -> bool:
+        return self.has_active_frame

--- a/wasm/datatypes/configuration.py
+++ b/wasm/datatypes/configuration.py
@@ -2,10 +2,6 @@ from typing import (
     NamedTuple,
 )
 
-from wasm.typing import (
-    Store,
-)
-
 from .instructions import (
     InstructionSequence,
 )
@@ -15,6 +11,9 @@ from .stack import (
     Label,
     LabelStack,
     ValueStack,
+)
+from .store import (
+    Store,
 )
 
 

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -29,6 +29,12 @@ class FunctionType(NamedTuple):
     params: Tuple[ValType, ...]
     results: Tuple[ValType, ...]
 
+    def __str__(self) -> str:
+        return f"FunctionType(params={self.params}, results={self.results})"
+
+    def __repr__(self) -> str:
+        return str(self)
+
 
 class Function(NamedTuple):
     """

--- a/wasm/datatypes/instructions.py
+++ b/wasm/datatypes/instructions.py
@@ -1,0 +1,69 @@
+from collections.abc import (
+    Sequence,
+)
+from typing import (
+    TYPE_CHECKING,
+    Iterator,
+    Tuple,
+    overload,
+)
+
+if TYPE_CHECKING:
+    from wasm.instructions import (  # noqa: F401
+        BaseInstruction,
+    )
+
+
+class InstructionSequence(Sequence):
+    _instructions: Tuple['BaseInstruction', ...]
+
+    def __init__(self, instructions: Tuple['BaseInstruction', ...]) -> None:
+        self._instructions = instructions
+        self._idx = -1
+
+    def __str__(self) -> str:
+        return f"[{' > '.join((str(instr) for instr in self._instructions))}]"
+
+    def __repr__(self) -> str:
+        return f"InstructionSequence({str(self)})"
+
+    def __len__(self) -> int:
+        return len(self._instructions)
+
+    def __next__(self) -> 'BaseInstruction':
+        self._idx += 1
+        try:
+            return self._instructions[self._idx]
+        except IndexError:
+            raise StopIteration
+
+    def __iter__(self) -> Iterator['BaseInstruction']:
+        while self._idx < len(self._instructions) - 1:
+            yield next(self)
+
+    @overload
+    def __getitem__(self, idx: int) -> 'BaseInstruction':
+        pass
+
+    @overload  # noqa: 811
+    def __getitem__(self, s: slice) -> 'InstructionSequence':
+        pass
+
+    def __getitem__(self, item):  # noqa: F811
+        if isinstance(item, int):
+            return self._instructions[item]
+        elif isinstance(item, slice):
+            return type(self)(self._instructions[item])
+        else:
+            raise TypeError(f"Unsupported key type: {type(item)}")
+
+    @property
+    def pc(self) -> int:
+        return max(0, self._idx)
+
+    @property
+    def current(self) -> 'BaseInstruction':
+        return self[self.pc]
+
+    def seek(self, idx: int) -> None:
+        self._idx = idx - 1

--- a/wasm/datatypes/stack.py
+++ b/wasm/datatypes/stack.py
@@ -1,0 +1,86 @@
+from typing import (
+    Generic,
+    Iterable,
+    List,
+    NamedTuple,
+    Tuple,
+    TypeVar,
+)
+import uuid
+
+from wasm.typing import (
+    TValue,
+)
+
+from .indices import (
+    LabelIdx,
+)
+from .instructions import (
+    InstructionSequence,
+)
+from .module import (
+    ModuleInstance,
+)
+
+TStackItem = TypeVar('TStackItem')
+
+
+class BaseStack(Generic[TStackItem]):
+    _stack: List[TStackItem]
+
+    def __init__(self) -> None:
+        self._stack = []
+
+    def __len__(self) -> int:
+        return len(self._stack)
+
+    def __bool__(self) -> bool:
+        return bool(self._stack)
+
+    def __iter__(self) -> Iterable[TStackItem]:
+        return iter(self._stack)
+
+    def pop(self) -> TStackItem:
+        return self._stack.pop()
+
+    def pop2(self) -> Tuple[TStackItem, TStackItem]:
+        return self._stack.pop(), self._stack.pop()
+
+    def pop3(self) -> Tuple[TStackItem, TStackItem, TStackItem]:
+        return self._stack.pop(), self._stack.pop(), self._stack.pop()
+
+    def push(self, value: TStackItem) -> None:
+        self._stack.append(value)
+
+    def peek(self) -> TStackItem:
+        return self._stack[-1]
+
+
+class ValueStack(BaseStack[TValue]):
+    pass
+
+
+class Frame(NamedTuple):
+    id: uuid.UUID
+    module: ModuleInstance
+    locals: List[TValue]
+    instructions: InstructionSequence
+    arity: int
+    height: int
+
+
+class FrameStack(BaseStack[Frame]):
+    pass
+
+
+class Label(NamedTuple):
+    arity: int
+    height: int
+    instructions: InstructionSequence
+    is_loop: bool
+    frame_id: uuid.UUID
+
+
+class LabelStack(BaseStack[Label]):
+    def get_by_label_idx(self, key: LabelIdx) -> Label:
+        return self._stack[-1 * (key + 1)]

--- a/wasm/datatypes/store.py
+++ b/wasm/datatypes/store.py
@@ -1,0 +1,28 @@
+from typing import (
+    List,
+    NamedTuple,
+    Union,
+)
+
+from .function import (
+    HostFunction,
+)
+from .globals import (
+    GlobalInstance,
+)
+from .memory import (
+    MemoryInstance,
+)
+from .module import (
+    FunctionInstance,
+)
+from .table import (
+    TableInstance,
+)
+
+
+class Store(NamedTuple):
+    funcs: List[Union[FunctionInstance, HostFunction]]
+    mems: List[MemoryInstance]
+    tables: List[TableInstance]
+    globals: List[GlobalInstance]

--- a/wasm/datatypes/val_type.py
+++ b/wasm/datatypes/val_type.py
@@ -15,6 +15,12 @@ class ValType(enum.Enum):
     f32 = 'f32'
     f64 = 'f64'
 
+    def __str__(self) -> str:
+        return self.value
+
+    def __repr__(self) -> str:
+        return str(self)
+
     @classmethod
     def from_byte(cls, byte: UInt8) -> 'ValType':
         if byte == 0x7f:

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -12,12 +12,12 @@ from wasm.datatypes import (
     MemoryType,
     ModuleInstance,
     Mutability,
+    Store,
     TableAddress,
     TableType,
     ValType,
 )
 from wasm.typing import (
-    Store,
     UInt32,
 )
 

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -17,6 +17,7 @@ from _pytest.outcomes import (
 import wasm
 from wasm.datatypes import (
     ModuleInstance,
+    Store,
 )
 from wasm.exceptions import (
     Exhaustion,
@@ -24,9 +25,6 @@ from wasm.exceptions import (
     MalformedModule,
     Trap,
     Unlinkable,
-)
-from wasm.typing import (
-    Store,
 )
 
 from .datatypes import (
@@ -156,10 +154,10 @@ def run_opcode_action_invoke(action, store, module, all_modules, registered_modu
         if type_.is_float_type:
             logger.info("Floating point not yet supported: %s", action)
             raise FloatingPointNotImplemented("Floating point not yet implemented")
-        args += [[type_.value + ".const", value]]
+        args.append((type_, value))
 
     # invoke func
-    _, ret = wasm.invoke_func(store, funcaddr, args)
+    _, ret = wasm.invoke_func(store, funcaddr, tuple(args))
 
     return ret
 
@@ -170,7 +168,7 @@ def run_opcode_action_get(action, store, module, all_modules, registered_modules
     for export in module.exports:
         if export.name == action.field:
             globaladdr = export.value
-            value = store["globals"][globaladdr].value
+            value = store.globals[globaladdr].value
             return [value]
     else:
         raise Exception(f"No export found for name: '{action.field}")

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -6,7 +6,6 @@ from pathlib import (
 )
 from typing import (
     Any,
-    Dict,
     List,
 )
 
@@ -59,7 +58,7 @@ def instantiate_module_from_wasm_file(
         file_path: Path,
         store: Store,
         registered_modules: List[ModuleInstance, ]
-) -> Dict[Any, Any]:
+) -> ModuleInstance:
     logger.debug("Loading wasm module from file: %s", file_path.name)
 
     if file_path.suffix != ".wasm":
@@ -90,7 +89,7 @@ def instantiate_module_from_wasm_file(
                 raise Unlinkable("Unlinkable module: export name not found")
 
             externvalstar += [externval]
-        _, moduleinst, _ = wasm.instantiate_module(store, module, externvalstar)
+        _, moduleinst, _ = wasm.instantiate_module(store, module, tuple(externvalstar))
     return moduleinst
 
 

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -1,15 +1,12 @@
 from typing import (
     Any,
     Callable,
-    Dict,
-    List,
     NewType,
     Tuple,
     Union,
 )
 
-Store = Dict[Any, Any]
-HostFunctionCallable = Callable[[Store, List[Any]], Tuple[Store, Any]]
+HostFunctionCallable = Callable[[Any, Any], Tuple[Any, Any]]
 
 
 UInt8 = NewType('UInt8', int)

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -9,7 +9,6 @@ from typing import (
 )
 
 Store = Dict[Any, Any]
-Config = Dict[Any, Any]
 HostFunctionCallable = Callable[[Store, List[Any]], Tuple[Store, Any]]
 
 


### PR DESCRIPTION
Builds on #45

## What was wrong?

The Web Assembly spec defines a "Store" which is a sort of global environment for wasm execution.

## How was it fixed?

Implemented the data structure using a `NamedTuple`.

This PR also contains the following cleanups:

1. Found and cleaned up one location where strings were still being used to represent types (in the type validation of arguments being passed into the wasm interpreter)
2. Removed multiple un-used and broken `spec_<thing>_inv` functions that had no test coverage and were not used (and won't be used because I'll be writing all of these new as stream based [serializers/composers/unparsers](https://stackoverflow.com/questions/148857/what-is-the-opposite-of-parse)
3. Enable full `flake8` linting on the `wasm.main` module.
4. Lots of cleanups for exception messages and broken f-strings (detected by linting)
5. Further filling in of missing type hints.

#### Cute Animal Picture


![cone_of_shame](https://user-images.githubusercontent.com/824194/52029493-a44fc700-24d0-11e9-87fc-82e37219e61f.jpg)
