### PR TITLE
Piper/extract and normalize memory table function limits validators

### DIFF
--- a/tests/core/validation/test_validate_function_type.py
+++ b/tests/core/validation/test_validate_function_type.py
@@ -1,0 +1,31 @@
+import pytest
+
+from wasm.datatypes import (
+    FunctionType,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_function_type,
+)
+
+
+def test_validate_function_type_without_results():
+    function_type = FunctionType((), ())
+
+    validate_function_type(function_type)
+
+
+def test_validate_function_type_with_single_result():
+    function_type = FunctionType((), (ValType.i32,))
+
+    validate_function_type(function_type)
+
+
+def test_validate_function_type_with_multiple_results():
+    function_type = FunctionType((), (ValType.i32, ValType.i32))
+
+    with pytest.raises(ValidationError, match="Function types may only have one result"):
+        validate_function_type(function_type)

--- a/tests/core/validation/test_validate_limits.py
+++ b/tests/core/validation/test_validate_limits.py
@@ -1,0 +1,44 @@
+import pytest
+
+from wasm import (
+    constants,
+)
+from wasm.datatypes import (
+    Limits,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_limits,
+)
+
+
+@pytest.mark.parametrize(
+    'limits,upper_bound,expected',
+    (
+        (Limits(0, None), 10, None),
+        (Limits(0, 10), 10, None),
+        (Limits(-1, 10), 10, "Limits.min is negative"),
+        (Limits(0, 11), 10, "Limits.max exceeds upper bound"),
+        (Limits(11, 20), 10, "Limits.min exceeds upper bound"),
+        (Limits(10, 9), 10, "Limits.min exceeds Limits.max"),
+        (
+            Limits(0, constants.UINT32_CEIL),
+            constants.UINT32_CEIL,
+            "Limits.max is outside of u32 range"
+        ),
+        (
+            Limits(constants.UINT32_CEIL, constants.UINT32_CEIL + 1),
+            constants.UINT32_CEIL + 1,
+            "Limits.min is outside of u32 range"
+        ),
+    ),
+)
+def test_validate_limits(limits, upper_bound, expected):
+    if expected is None:
+        # should be valid
+        validate_limits(limits, upper_bound)
+    else:
+        with pytest.raises(ValidationError, match=expected):
+            validate_limits(limits, upper_bound)

--- a/tests/core/validation/test_validate_memory.py
+++ b/tests/core/validation/test_validate_memory.py
@@ -1,0 +1,25 @@
+import pytest
+
+from wasm.datatypes import (
+    Memory,
+    MemoryType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_memory,
+)
+
+
+def test_validate_memory_success():
+    memory = Memory(MemoryType(0, 2**16))
+
+    validate_memory(memory)
+
+
+def test_validate_memory_failure():
+    memory = Memory(MemoryType(0, 2**16 + 1))
+
+    with pytest.raises(ValidationError, match="Limits.max exceeds upper bound"):
+        validate_memory(memory)

--- a/tests/core/validation/test_validate_memory_type.py
+++ b/tests/core/validation/test_validate_memory_type.py
@@ -1,0 +1,24 @@
+import pytest
+
+from wasm.datatypes import (
+    MemoryType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_memory_type,
+)
+
+
+def test_validate_memory_type_success():
+    memory_type = MemoryType(0, 2**16)
+
+    validate_memory_type(memory_type)
+
+
+def test_validate_memory_type_failure():
+    memory_type = MemoryType(0, 2**16 + 1)
+
+    with pytest.raises(ValidationError, match="Limits.max exceeds upper bound"):
+        validate_memory_type(memory_type)

--- a/tests/core/validation/test_validate_table.py
+++ b/tests/core/validation/test_validate_table.py
@@ -1,0 +1,34 @@
+import pytest
+
+from wasm.datatypes import (
+    FunctionAddress,
+    Limits,
+    Table,
+    TableType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_table,
+)
+
+
+def test_validate_table_success():
+    table = Table(TableType(Limits(0, 100), FunctionAddress))
+
+    validate_table(table)
+
+
+@pytest.mark.parametrize(
+    'table_type,match',
+    (
+        (TableType(Limits(10, 9), FunctionAddress), 'Limits'),
+        (TableType(Limits(0, 100), None), 'FunctionAddress'),
+    )
+)
+def test_validate_table_type_failures(table_type, match):
+    table = Table(table_type)
+
+    with pytest.raises(ValidationError, match=match):
+        validate_table(table)

--- a/tests/core/validation/test_validate_table_type.py
+++ b/tests/core/validation/test_validate_table_type.py
@@ -1,0 +1,32 @@
+import pytest
+
+from wasm.datatypes import (
+    FunctionAddress,
+    Limits,
+    TableType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.validation import (
+    validate_table_type,
+)
+
+
+def test_validate_table_type_success():
+    table_type = TableType(Limits(0, 100), FunctionAddress)
+
+    validate_table_type(table_type)
+
+
+@pytest.mark.parametrize(
+    'table_type,match',
+    (
+        (TableType(Limits(10, 9), FunctionAddress), 'Limits'),
+        (TableType(Limits(0, 100), None), 'FunctionAddress'),
+    )
+)
+def test_validate_table_type_failures(table_type, match):
+
+    with pytest.raises(ValidationError, match=match):
+        validate_table_type(table_type)

--- a/wasm/validation/__init__.py
+++ b/wasm/validation/__init__.py
@@ -1,3 +1,17 @@
 from .context import (  # noqa: F401
     Context,
 )
+from .function import (  # noqa: F401
+    validate_function_type,
+)
+from .limits import (  # noqa: F401
+    validate_limits,
+)
+from .memory import (  # noqa: F401
+    validate_memory,
+    validate_memory_type,
+)
+from .tables import (  # noqa: F401
+    validate_table,
+    validate_table_type,
+)

--- a/wasm/validation/function.py
+++ b/wasm/validation/function.py
@@ -1,0 +1,13 @@
+from wasm.datatypes import (
+    FunctionType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+
+
+def validate_function_type(function_type: FunctionType) -> None:
+    if len(function_type.results) > 1:
+        raise ValidationError(
+            f"Function types may only have one result.  Got {len(function_type.results)}"
+        )

--- a/wasm/validation/limits.py
+++ b/wasm/validation/limits.py
@@ -1,0 +1,31 @@
+from wasm import (
+    constants,
+)
+from wasm.datatypes import (
+    Limits,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+
+
+def validate_limits(limits: Limits, upper_bound: int) -> None:
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#limits%E2%91%A2
+    """
+    if limits.min > constants.UINT32_MAX:
+        raise ValidationError("Limits.min is outside of u32 range: Got {limits.min}")
+    elif limits.min < 0:
+        raise ValidationError("Limits.min is negative: Got {limits.min}")
+    elif limits.min > upper_bound:
+        raise ValidationError(f"Limits.min exceeds upper bound: {limits.min} > {upper_bound}")
+    elif limits.max is not None:
+        if limits.max > constants.UINT32_MAX:
+            raise ValidationError("Limits.max is outside of u32 range: Got {limits.max}")
+        elif limits.max > upper_bound:
+            raise ValidationError(f"Limits.max exceeds upper bound: {limits.max} > {upper_bound}")
+        elif limits.min > limits.max:
+            raise ValidationError(
+                f"Limits.min exceeds Limits.max: {limits.min} > "
+                f"{limits.max}"
+            )

--- a/wasm/validation/memory.py
+++ b/wasm/validation/memory.py
@@ -1,0 +1,21 @@
+from wasm import (
+    constants,
+)
+from wasm.datatypes import (
+    Limits,
+    Memory,
+    MemoryType,
+)
+
+from .limits import (
+    validate_limits,
+)
+
+
+def validate_memory_type(memory_type: MemoryType) -> None:
+    limits = Limits(memory_type.min, memory_type.max)
+    validate_limits(limits, constants.UINT16_CEIL)
+
+
+def validate_memory(memory: Memory) -> None:
+    validate_memory_type(memory.type)

--- a/wasm/validation/tables.py
+++ b/wasm/validation/tables.py
@@ -1,0 +1,33 @@
+from wasm import (
+    constants,
+)
+from wasm.datatypes import (
+    FunctionAddress,
+    Table,
+    TableType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+
+from .limits import (
+    validate_limits,
+)
+
+
+def validate_table_type(table_type: TableType) -> None:
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#table-types%E2%91%A2
+    """
+    validate_limits(table_type.limits, constants.UINT32_CEIL)
+    if table_type.elem_type is not FunctionAddress:
+        raise ValidationError(
+            f"TableType.elem_type must be `FunctionAddress`: Got {table_type.elem_type}"
+        )
+
+
+def validate_table(table: Table) -> None:
+    """
+    https://webassembly.github.io/spec/core/bikeshed/index.html#tables%E2%91%A2
+    """
+    return validate_table_type(table.type)


### PR DESCRIPTION
Builds on #46 

## What was wrong?

Goal is to eventually do away with `wasm.main`

## How was it fixed?

This extracts a few validation functions from the `wasm.main` module, organizing them within the `wasm.validation` module, and writing tests for each of them.

#### Cute Animal Picture

![coneofshame_6a9aa4_4276267](https://user-images.githubusercontent.com/824194/52078624-e4ef2500-2550-11e9-8a38-c4497e57f854.jpg)

