### PR TITLE
Extract and formalize expression validation

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -68,6 +68,7 @@ from .stack import (  # noqa: F401
     FrameStack,
     Label,
     LabelStack,
+    BaseStack,
     ValueStack,
 )
 from .store import (  # noqa: F401

--- a/wasm/datatypes/stack.py
+++ b/wasm/datatypes/stack.py
@@ -1,10 +1,14 @@
+from collections.abc import (
+    Sequence,
+)
 from typing import (
     Generic,
-    Iterable,
+    Iterator,
     List,
     NamedTuple,
     Tuple,
     TypeVar,
+    overload,
 )
 import uuid
 
@@ -25,7 +29,7 @@ from .module import (
 TStackItem = TypeVar('TStackItem')
 
 
-class BaseStack(Generic[TStackItem]):
+class BaseStack(Sequence, Generic[TStackItem]):
     _stack: List[TStackItem]
 
     def __init__(self) -> None:
@@ -37,8 +41,24 @@ class BaseStack(Generic[TStackItem]):
     def __bool__(self) -> bool:
         return bool(self._stack)
 
-    def __iter__(self) -> Iterable[TStackItem]:
+    def __iter__(self) -> Iterator[TStackItem]:
         return iter(self._stack)
+
+    @overload
+    def __getitem__(self, idx: int) -> TStackItem:
+        pass
+
+    @overload  # noqa: 811
+    def __getitem__(self, s: slice) -> 'Sequence[TStackItem]':
+        pass
+
+    def __getitem__(self, item):  # noqa: F811
+        if isinstance(item, int):
+            return self._instructions[item]
+        elif isinstance(item, slice):
+            return self._instructions[item]
+        else:
+            raise TypeError(f"Unsupported key type: {type(item)}")
 
     def pop(self) -> TStackItem:
         return self._stack.pop()

--- a/wasm/validation/__init__.py
+++ b/wasm/validation/__init__.py
@@ -1,6 +1,10 @@
 from .context import (  # noqa: F401
     Context,
 )
+from .expressions import (  # noqa: F401
+    validate_constant_expression,
+    validate_expression,
+)
 from .function import (  # noqa: F401
     validate_function_type,
 )

--- a/wasm/validation/context.py
+++ b/wasm/validation/context.py
@@ -4,22 +4,42 @@ from typing import (
 )
 
 from wasm.datatypes import (
+    FuncIdx,
     FunctionType,
+    GlobalIdx,
     GlobalType,
+    LocalIdx,
+    MemoryIdx,
     MemoryType,
+    TableIdx,
     TableType,
+    TypeIdx,
     ValType,
 )
 from wasm.exceptions import (
-    InvalidModule,
+    ValidationError,
 )
+
+from .operand import (
+    Operand,
+)
+from .stack import (
+    ControlFrame,
+    ControlStack,
+    OperandStack,
+)
+from .unknown import (
+    Unknown as _Unkown,
+)
+
+Unknown = _Unkown.Unknown
 
 
 class Context:
     def __init__(self,
                  *,
                  types: Tuple[FunctionType, ...],
-                 funcs: Tuple[FunctionType, ...],
+                 functions: Tuple[FunctionType, ...],
                  tables: Tuple[TableType, ...],
                  mems: Tuple[MemoryType, ...],
                  globals: Tuple[GlobalType, ...],
@@ -30,18 +50,20 @@ class Context:
                  returns: Union[None, Tuple[ValType, ...]],
                  ) -> None:
         self.types = types
-        self.funcs = funcs
+        self.functions = functions
         self.tables = tables
         self.mems = mems
         self.globals = globals
         self.locals = locals
         self.labels = labels
         self.returns = returns
+        self.operand_stack = OperandStack()
+        self.control_stack = ControlStack()
 
     def prime(self,
               *,
               types: Tuple[FunctionType, ...] = None,
-              funcs: Tuple[FunctionType, ...] = None,
+              functions: Tuple[FunctionType, ...] = None,
               tables: Tuple[TableType, ...] = None,
               mems: Tuple[MemoryType, ...] = None,
               globals: Tuple[GlobalType, ...] = None,
@@ -50,7 +72,7 @@ class Context:
               returns: Tuple[ValType, ...] = None) -> 'Context':
         return type(self)(
             types=types or self.types,
-            funcs=funcs or self.funcs,
+            functions=functions or self.functions,
             tables=tables or self.tables,
             mems=mems or self.mems,
             globals=globals or self.globals,
@@ -60,91 +82,159 @@ class Context:
         )
 
     #
+    # Opocode Validation
+    #
+    def mark_unreachable(self) -> None:
+        """
+        Mark the current frame as unreachable.
+        """
+        frame = self.control_stack.pop()
+        while len(self.operand_stack) > frame.height:
+            self.operand_stack.pop()
+        self.control_stack.push(frame.mark_unreachable())
+
+    def push_control_frame(self,
+                           label_types: Tuple[ValType, ...],
+                           end_types: Tuple[ValType, ...]) -> None:
+        """
+        Mark the entry into a new control frame (such as encountering a BLOCK or IF instruction)
+        """
+        frame = ControlFrame(label_types, end_types, len(self.operand_stack), False)
+        self.control_stack.push(frame)
+
+    def pop_control_frame(self) -> ControlFrame:
+        try:
+            frame = self.control_stack.peek()
+        except IndexError:
+            raise ValidationError("Attempt to pop from empty control stack")
+
+        self.pop_operands_of_expected_types(frame.end_types)
+
+        if len(self.operand_stack) != frame.height:
+            raise ValidationError(
+                f"Operand stack height invalid.  Expected: {frame.height}  Got: "
+                f"{len(self.operand_stack)}"
+            )
+        return self.control_stack.pop()
+
+    def pop_operand(self) -> Operand:
+        frame = self.control_stack.peek()
+
+        if frame.is_unreachable and len(self.operand_stack) == frame.height:
+            return Unknown
+        elif len(self.operand_stack) <= frame.height:
+            raise ValidationError(
+                f"Underflow: Insufficient operands: {len(self.operand_stack)} <= "
+                f"{frame.height}"
+            )
+        else:
+            return self.operand_stack.pop()
+
+    def pop_operand_and_assert_type(self, expected: Operand) -> Operand:
+        actual = self.pop_operand()
+
+        if actual is Unknown or expected is Unknown:
+            return expected
+        elif actual == expected:
+            return actual
+        else:
+            raise ValidationError(
+                f"Type mismatch on operand stack.  Expected: {expected}  Got: "
+                f"{actual}"
+            )
+
+    def pop_operands_of_expected_types(self,
+                                       expected_types: Tuple[ValType, ...],
+                                       ) -> None:
+        for expected in reversed(expected_types):
+            self.pop_operand_and_assert_type(expected)
+
+    #
     # Types
     #
-    def validate_type_idx(self, idx: int) -> None:
+    def validate_type_idx(self, idx: TypeIdx) -> None:
         if not self.has_type(idx):
-            raise InvalidModule(
+            raise ValidationError(
                 f"Types index outside of valid range: {idx} >= {len(self.types)}"
             )
 
-    def has_type(self, idx: int) -> bool:
+    def has_type(self, idx: TypeIdx) -> bool:
         return idx < len(self.types)
 
-    def get_type(self, idx: int) -> FunctionType:
+    def get_type(self, idx: TypeIdx) -> FunctionType:
         return self.types[idx]
 
     #
     # Functions
     #
-    def validate_func_idx(self, idx: int) -> None:
-        if not self.has_func(idx):
-            raise InvalidModule(
-                f"Function index outside of valid range: {idx} >= {len(self.funcs)}"
+    def validate_function_idx(self, idx: FuncIdx) -> None:
+        if not self.has_function(idx):
+            raise ValidationError(
+                f"Function index outside of valid range: {idx} >= {len(self.functions)}"
             )
 
-    def has_func(self, idx: int) -> bool:
-        return idx < len(self.funcs)
+    def has_function(self, idx: FuncIdx) -> bool:
+        return idx < len(self.functions)
 
-    def get_func(self, idx: int) -> FunctionType:
-        return self.funcs[idx]
+    def get_function(self, idx: FuncIdx) -> FunctionType:
+        return self.functions[idx]
 
     #
     # Tables
     #
-    def validate_table_idx(self, idx: int) -> None:
+    def validate_table_idx(self, idx: TableIdx) -> None:
         if not self.has_table(idx):
-            raise InvalidModule(
+            raise ValidationError(
                 f"Table index outside of valid range: {idx} >= {len(self.tables)}"
             )
 
-    def has_table(self, idx: int) -> bool:
+    def has_table(self, idx: TableIdx) -> bool:
         return idx < len(self.tables)
 
-    def get_table(self, idx: int) -> TableType:
+    def get_table(self, idx: TableIdx) -> TableType:
         return self.tables[idx]
 
     #
     # Memory
     #
-    def validate_mem_idx(self, idx: int) -> None:
+    def validate_mem_idx(self, idx: MemoryIdx) -> None:
         if not self.has_mem(idx):
-            raise InvalidModule(
+            raise ValidationError(
                 f"Memory index outside of valid range: {idx} >= {len(self.mems)}"
             )
 
-    def has_mem(self, idx: int) -> bool:
+    def has_mem(self, idx: MemoryIdx) -> bool:
         return idx < len(self.mems)
 
-    def get_mem(self, idx: int) -> MemoryType:
+    def get_mem(self, idx: MemoryIdx) -> MemoryType:
         return self.mems[idx]
 
     #
     # Global
     #
-    def validate_global_idx(self, idx: int) -> None:
+    def validate_global_idx(self, idx: GlobalIdx) -> None:
         if not self.has_global(idx):
-            raise InvalidModule(
+            raise ValidationError(
                 f"Global index outside of valid range: {idx} >= {len(self.globals)}"
             )
 
-    def has_global(self, idx: int) -> bool:
+    def has_global(self, idx: GlobalIdx) -> bool:
         return idx < len(self.globals)
 
-    def get_global(self, idx: int) -> GlobalType:
+    def get_global(self, idx: GlobalIdx) -> GlobalType:
         return self.globals[idx]
 
     #
     # Locals
     #
-    def validate_local_idx(self, idx: int) -> None:
+    def validate_local_idx(self, idx: LocalIdx) -> None:
         if not self.has_local(idx):
-            raise InvalidModule(
+            raise ValidationError(
                 f"Locals index outside of valid range: {idx} >= {len(self.locals)}"
             )
 
-    def has_local(self, idx: int) -> bool:
+    def has_local(self, idx: LocalIdx) -> bool:
         return idx < len(self.locals)
 
-    def get_local(self, idx: int) -> ValType:
+    def get_local(self, idx: LocalIdx) -> ValType:
         return self.locals[idx]

--- a/wasm/validation/control.py
+++ b/wasm/validation/control.py
@@ -1,0 +1,160 @@
+from typing import (
+    cast,
+)
+
+from wasm.datatypes import (
+    TableIdx,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Call,
+    CallIndirect,
+    Else,
+    If,
+    Loop,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+
+
+def validate_control_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode is BinaryOpcode.UNREACHABLE:
+        validate_unreachable(context)
+    elif instruction.opcode is BinaryOpcode.BLOCK:
+        validate_block(cast(Block, instruction), context)
+    elif instruction.opcode is BinaryOpcode.END:
+        validate_end(context)
+    elif instruction.opcode is BinaryOpcode.IF:
+        validate_if(cast(If, instruction), context)
+    elif instruction.opcode is BinaryOpcode.ELSE:
+        validate_else(cast(Else, instruction), context)
+    elif instruction.opcode is BinaryOpcode.LOOP:
+        validate_loop(cast(Loop, instruction), context)
+    elif instruction.opcode is BinaryOpcode.BR:
+        validate_br(cast(Br, instruction), context)
+    elif instruction.opcode is BinaryOpcode.BR_IF:
+        validate_br_if(cast(BrIf, instruction), context)
+    elif instruction.opcode is BinaryOpcode.BR_TABLE:
+        validate_br_table(cast(BrTable, instruction), context)
+    elif instruction.opcode is BinaryOpcode.NOP:
+        pass  # NOP is always valid
+    elif instruction.opcode is BinaryOpcode.CALL:
+        validate_call(cast(Call, instruction), context)
+    elif instruction.opcode is BinaryOpcode.CALL_INDIRECT:
+        validate_call_indirect(cast(CallIndirect, instruction), context)
+    elif instruction.opcode is BinaryOpcode.RETURN:
+        validate_return(context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_unreachable(context: Context) -> None:
+    context.mark_unreachable()
+
+
+def validate_block(instruction: Block, context: Context) -> None:
+    context.push_control_frame(instruction.result_type, instruction.result_type)
+
+
+def validate_if(instruction: If, context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.push_control_frame(instruction.result_type, instruction.result_type)
+
+
+def validate_else(instruction: Else, context: Context) -> None:
+    frame = context.pop_control_frame()
+    context.push_control_frame(frame.end_types, frame.end_types)
+
+
+def validate_br_if(instruction: BrIf, context: Context) -> None:
+    context.control_stack.validate_label_idx(instruction.label_idx)
+
+    frame = context.control_stack.get_by_label_idx(instruction.label_idx)
+    label_types = frame.label_types
+
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.pop_operands_of_expected_types(label_types)
+
+    for valtype in label_types:
+        context.operand_stack.push(valtype)
+
+
+def validate_end(context: Context) -> None:
+    frame = context.pop_control_frame()
+    for valtype in frame.end_types:
+        context.operand_stack.push(valtype)
+
+
+def validate_loop(instruction: Loop, context: Context) -> None:
+    context.push_control_frame(tuple(), instruction.result_type)
+
+
+def validate_br(instruction: Br, context: Context) -> None:
+    context.control_stack.validate_label_idx(instruction.label_idx)
+
+    frame = context.control_stack.get_by_label_idx(instruction.label_idx)
+    expected_label_types = frame.label_types
+
+    context.pop_operands_of_expected_types(expected_label_types)
+    context.mark_unreachable()
+
+
+def validate_br_table(instruction: BrTable, context: Context) -> None:
+    context.control_stack.validate_label_idx(instruction.default_idx)
+
+    frame = context.control_stack.get_by_label_idx(instruction.default_idx)
+    expected_label_types = frame.label_types
+
+    for idx, label_idx in enumerate(instruction.label_indices):
+        context.control_stack.validate_label_idx(label_idx)
+        label_frame = context.control_stack.get_by_label_idx(label_idx)
+
+        if label_frame.label_types != expected_label_types:
+            raise ValidationError(
+                f"Label index at position {idx} has incorrect type.  Expected: "
+                f"{expected_label_types}  Got: {label_frame.label_types}"
+            )
+
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.pop_operands_of_expected_types(expected_label_types)
+    context.mark_unreachable()
+
+
+def validate_call(instruction: Call, context: Context) -> None:
+    context.validate_function_idx(instruction.func_idx)
+    function_type = context.get_function(instruction.func_idx)
+
+    context.pop_operands_of_expected_types(function_type.params)
+    for valtype in function_type.results:
+        context.operand_stack.push(valtype)
+
+
+def validate_call_indirect(instruction: CallIndirect, context: Context) -> None:
+    context.validate_table_idx(TableIdx(0))
+    context.validate_type_idx(instruction.type_idx)
+    function_type = context.get_type(instruction.type_idx)
+
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.pop_operands_of_expected_types(function_type.params)
+
+    for valtype in function_type.results:
+        context.operand_stack.push(valtype)
+
+
+def validate_return(context: Context) -> None:
+    if context.returns is not None:
+        context.pop_operands_of_expected_types(context.returns)
+    context.mark_unreachable()

--- a/wasm/validation/control_frame.py
+++ b/wasm/validation/control_frame.py
@@ -1,0 +1,23 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+)
+
+from wasm.datatypes import (
+    ValType,
+)
+
+
+class ControlFrame(NamedTuple):
+    label_types: Tuple[ValType, ...]
+    end_types: Tuple[ValType, ...]
+    height: int
+    is_unreachable: bool
+
+    def mark_unreachable(self) -> 'ControlFrame':
+        return type(self)(
+            self.label_types,
+            self.end_types,
+            self.height,
+            True,
+        )

--- a/wasm/validation/expressions.py
+++ b/wasm/validation/expressions.py
@@ -1,0 +1,83 @@
+import logging
+from typing import (
+    Tuple,
+    Union,
+    cast,
+)
+
+from wasm.exceptions import (
+    InvalidModule,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    Block,
+    If,
+    Loop,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+from .instructions import (
+    validate_constant_instruction,
+    validate_instruction,
+)
+
+logger = logging.getLogger('wasm.validation.expression')
+
+
+BLOCK_LOOP_IF = {
+    BinaryOpcode.BLOCK,
+    BinaryOpcode.LOOP,
+    BinaryOpcode.IF,
+}
+
+
+def validate_expression(expression: Tuple[BaseInstruction, ...],
+                        context: Context) -> None:
+    for idx, instruction in enumerate(expression):
+        if not isinstance(instruction, BaseInstruction):
+            # TODO: use a different exceptin since this represents an internal
+            # failure.
+            raise InvalidModule(
+                f"Unrecognized instruction: {repr(instruction)} found at index "
+                f"{idx}"
+            )
+
+        logger.debug('Validating instruction: %s', instruction)
+
+        # SIDE-EFFECT: Instruction validation is inherently
+        # stateful/side-effect causing.  Both `Context.operand_stack` and
+        # `Context.control_stack` end up being mutated over the course of
+        # expression validation to keep track of things like the expected
+        # number of operands on the stack and their types.
+        validate_instruction(instruction, context)
+
+        # recurse for block, loop, if
+        if instruction.opcode in BLOCK_LOOP_IF:
+            sub_instructions = cast(Union[Block, Loop, If], instruction).instructions
+            # RECURSION
+            validate_expression(sub_instructions, context)
+
+            if instruction.opcode is BinaryOpcode.IF:
+                else_instructions = cast(If, instruction).else_instructions
+                # RECURSION
+                validate_expression(else_instructions, context)
+
+
+def validate_constant_expression(expression: Tuple[BaseInstruction, ...],
+                                 context: Context) -> None:
+    for idx, instruction in enumerate(expression[:-1]):
+        if not isinstance(instruction, BaseInstruction):
+            # TODO: use a different exceptin since this represents an internal
+            # failure.
+            raise InvalidModule(
+                f"Unrecognized instruction: {repr(instruction)} found at index "
+                f"{idx}"
+            )
+        logger.debug('Validating instruction: %s', instruction)
+
+        validate_constant_instruction(instruction, context)

--- a/wasm/validation/instructions.py
+++ b/wasm/validation/instructions.py
@@ -1,0 +1,74 @@
+from typing import (
+    cast,
+)
+
+from wasm.datatypes import (
+    Mutability,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    GlobalOp,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+from .control import (
+    validate_control_instruction,
+)
+from .memory import (
+    validate_memory_instruction,
+)
+from .numeric import (
+    TNumericConstant,
+    validate_numeric_constant,
+    validate_numeric_instruction,
+)
+from .parametric import (
+    validate_parametric_instruction,
+)
+from .variable import (
+    validate_get_global,
+    validate_variable_instruction,
+)
+
+
+def validate_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode.is_control:
+        validate_control_instruction(instruction, context)
+    elif instruction.opcode.is_variable:
+        validate_variable_instruction(instruction, context)
+    elif instruction.opcode.is_memory:
+        validate_memory_instruction(instruction, context)
+    elif instruction.opcode.is_parametric:
+        validate_parametric_instruction(instruction, context)
+    elif instruction.opcode.is_numeric:
+        validate_numeric_instruction(instruction, context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_constant_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode is BinaryOpcode.GET_GLOBAL:
+        global_ = context.get_global(cast(GlobalOp, instruction).global_idx)
+
+        if global_.mut is not Mutability.const:
+            raise ValidationError(
+                "Attempt to access mutable global variable within constant "
+                "expression"
+            )
+        validate_get_global(cast(GlobalOp, instruction), context)
+    elif instruction.opcode.is_numeric_constant:
+        validate_numeric_constant(cast(TNumericConstant, instruction), context)
+    else:
+        raise ValidationError(
+            "Illegal instruction.  Only "
+            "I32_CONST/I64_CONST/F32_CONST/F64_CONST/GET_GLOBAL are allowed. "
+            f"Got {instruction.opcode}"
+        )

--- a/wasm/validation/memory.py
+++ b/wasm/validation/memory.py
@@ -1,12 +1,31 @@
+from typing import (
+    cast,
+)
+
 from wasm import (
     constants,
 )
 from wasm.datatypes import (
     Limits,
     Memory,
+    MemoryIdx,
     MemoryType,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    MemoryOp,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
 )
 
+from .context import (
+    Context,
+)
 from .limits import (
     validate_limits,
 )
@@ -19,3 +38,51 @@ def validate_memory_type(memory_type: MemoryType) -> None:
 
 def validate_memory(memory: Memory) -> None:
     validate_memory_type(memory.type)
+
+
+def validate_memory_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode.is_memory_load:
+        validate_memory_load(cast(MemoryOp, instruction), context)
+    elif instruction.opcode.is_memory_store:
+        validate_memory_store(cast(MemoryOp, instruction), context)
+    elif instruction.opcode is BinaryOpcode.MEMORY_SIZE:
+        validate_memory_size(context)
+    elif instruction.opcode is BinaryOpcode.MEMORY_GROW:
+        validate_memory_grow(context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_memory_load(instruction: MemoryOp, context: Context) -> None:
+    context.validate_mem_idx(MemoryIdx(0))
+
+    align_ceil = instruction.memory_bit_size.value // 8
+    if 2 ** instruction.memarg.align > align_ceil:
+        raise ValidationError("Invalid memarg alignment")
+
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_memory_store(instruction: MemoryOp, context: Context) -> None:
+    context.validate_mem_idx(MemoryIdx(0))
+
+    align_ceil = instruction.memory_bit_size.value // 8
+    if 2 ** instruction.memarg.align > align_ceil:
+        raise ValidationError("Invalid memarg alignment")
+
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.pop_operand_and_assert_type(ValType.i32)
+
+
+def validate_memory_size(context: Context) -> None:
+    context.validate_mem_idx(MemoryIdx(0))
+
+    context.operand_stack.push(ValType.i32)
+
+
+def validate_memory_grow(context: Context) -> None:
+    context.validate_mem_idx(MemoryIdx(0))
+
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.operand_stack.push(ValType.i32)

--- a/wasm/validation/numeric.py
+++ b/wasm/validation/numeric.py
@@ -1,0 +1,130 @@
+from typing import (
+    Union,
+    cast,
+)
+
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    BinOp,
+    Convert,
+    F32Const,
+    F64Const,
+    I32Const,
+    I64Const,
+    Reinterpret,
+    RelOp,
+    TestOp,
+    Truncate,
+    UnOp,
+    Wrap,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+
+TNumericConstant = Union[I32Const, I64Const, F32Const, F64Const]
+TConversion = Union[Wrap, Truncate, Convert, Reinterpret]
+
+
+def validate_numeric_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode.is_numeric_constant:
+        validate_numeric_constant(cast(TNumericConstant, instruction), context)
+    elif instruction.opcode.is_relop:
+        validate_relop(cast(RelOp, instruction), context)
+    elif instruction.opcode.is_unop:
+        validate_unop(cast(UnOp, instruction), context)
+    elif instruction.opcode.is_binop:
+        validate_binop(cast(BinOp, instruction), context)
+    elif instruction.opcode.is_testop:
+        validate_testop(cast(TestOp, instruction), context)
+    elif instruction.opcode.is_conversion:
+        validate_conversion(cast(TConversion, instruction), context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_numeric_constant(instruction: TNumericConstant, context: Context) -> None:
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_relop(instruction: RelOp, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.operand_stack.push(ValType.i32)
+
+
+def validate_unop(instruction: UnOp, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_binop(instruction: BinOp, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_testop(instruction: TestOp, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.valtype)
+    context.operand_stack.push(ValType.i32)
+
+
+def validate_conversion(instruction: TConversion, context: Context) -> None:
+    if instruction.opcode is BinaryOpcode.I32_WRAP_I64:
+        validate_wrap(context)
+    elif instruction.opcode in {BinaryOpcode.I64_EXTEND_S_I32, BinaryOpcode.I64_EXTEND_U_I32}:
+        validate_extend(context)
+    elif instruction.opcode.is_truncate:
+        validate_truncate(cast(Truncate, instruction), context)
+    elif instruction.opcode.is_convert:
+        validate_convert(cast(Convert, instruction), context)
+    elif instruction.opcode is BinaryOpcode.F64_PROMOTE_F32:
+        validate_promote(context)
+    elif instruction.opcode is BinaryOpcode.F32_DEMOTE_F64:
+        validate_demote(context)
+    elif instruction.opcode.is_reinterpret:
+        validate_reinterpret(cast(Reinterpret, instruction), context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_wrap(context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.i64)
+    context.operand_stack.push(ValType.i32)
+
+
+def validate_extend(context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.i32)
+    context.operand_stack.push(ValType.i64)
+
+
+def validate_truncate(instruction: Truncate, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.result)
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_convert(instruction: Convert, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.result)
+    context.operand_stack.push(instruction.valtype)
+
+
+def validate_promote(context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.f32)
+    context.operand_stack.push(ValType.f64)
+
+
+def validate_demote(context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.f64)
+    context.operand_stack.push(ValType.f32)
+
+
+def validate_reinterpret(instruction: Reinterpret, context: Context) -> None:
+    context.pop_operand_and_assert_type(instruction.result)
+    context.operand_stack.push(instruction.valtype)

--- a/wasm/validation/operand.py
+++ b/wasm/validation/operand.py
@@ -1,0 +1,13 @@
+from typing import (
+    Union,
+)
+
+from wasm.datatypes import (
+    ValType,
+)
+
+from .unknown import (
+    Unknown,
+)
+
+Operand = Union[ValType, Unknown]

--- a/wasm/validation/parametric.py
+++ b/wasm/validation/parametric.py
@@ -1,0 +1,36 @@
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.instructions import (
+    BaseInstruction,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+
+
+#
+# Parametric Instructions
+#
+def validate_parametric_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode is BinaryOpcode.DROP:
+        validate_drop(context)
+    elif instruction.opcode is BinaryOpcode.SELECT:
+        validate_select(context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_drop(context: Context) -> None:
+    context.pop_operand()
+
+
+def validate_select(context: Context) -> None:
+    context.pop_operand_and_assert_type(ValType.i32)
+    valtype = context.pop_operand()
+    context.pop_operand_and_assert_type(valtype)
+    context.operand_stack.push(valtype)

--- a/wasm/validation/stack.py
+++ b/wasm/validation/stack.py
@@ -1,0 +1,30 @@
+from wasm.datatypes import (
+    BaseStack,
+    LabelIdx,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+
+from .control_frame import (
+    ControlFrame,
+)
+from .operand import (
+    Operand,
+)
+
+
+class ControlStack(BaseStack[ControlFrame]):
+    def get_by_label_idx(self, key: LabelIdx) -> ControlFrame:
+        return self._stack[-1 * (key + 1)]
+
+    def validate_label_idx(self, label_idx: LabelIdx) -> None:
+        if label_idx >= len(self):
+            raise ValidationError(
+                "Label index exceeds number of available control frames: "
+                f"{label_idx} > {len(self)}"
+            )
+
+
+class OperandStack(BaseStack[Operand]):
+    pass

--- a/wasm/validation/unknown.py
+++ b/wasm/validation/unknown.py
@@ -1,0 +1,8 @@
+import enum
+
+
+class Unknown(enum.Enum):
+    """
+    Sentinal value to represent an unknown operand value type.
+    """
+    Unknown = "Unknown"

--- a/wasm/validation/variable.py
+++ b/wasm/validation/variable.py
@@ -1,0 +1,78 @@
+from typing import (
+    cast,
+)
+
+from wasm.datatypes import (
+    Mutability,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    GlobalOp,
+    LocalOp,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from .context import (
+    Context,
+)
+
+
+#
+# Variable Instructions
+#
+def validate_variable_instruction(instruction: BaseInstruction, context: Context) -> None:
+    if instruction.opcode is BinaryOpcode.GET_LOCAL:
+        validate_get_local(cast(LocalOp, instruction), context)
+    elif instruction.opcode is BinaryOpcode.SET_LOCAL:
+        validate_set_local(cast(LocalOp, instruction), context)
+    elif instruction.opcode is BinaryOpcode.TEE_LOCAL:
+        validate_tee_local(cast(LocalOp, instruction), context)
+    elif instruction.opcode is BinaryOpcode.GET_GLOBAL:
+        validate_get_global(cast(GlobalOp, instruction), context)
+    elif instruction.opcode is BinaryOpcode.SET_GLOBAL:
+        validate_set_global(cast(GlobalOp, instruction), context)
+    else:
+        raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
+
+
+def validate_get_local(instruction: LocalOp, context: Context) -> None:
+    context.validate_local_idx(instruction.local_idx)
+    valtype = context.get_local(instruction.local_idx)
+    context.operand_stack.push(valtype)
+
+
+def validate_set_local(instruction: LocalOp, context: Context) -> None:
+    context.validate_local_idx(instruction.local_idx)
+    valtype = context.get_local(instruction.local_idx)
+    context.pop_operand_and_assert_type(valtype)
+
+
+def validate_tee_local(instruction: LocalOp, context: Context) -> None:
+    context.validate_local_idx(instruction.local_idx)
+    valtype = context.get_local(instruction.local_idx)
+    context.pop_operand_and_assert_type(valtype)
+    context.operand_stack.push(valtype)
+
+
+def validate_get_global(instruction: GlobalOp, context: Context) -> None:
+    context.validate_global_idx(instruction.global_idx)
+    global_ = context.get_global(instruction.global_idx)
+    context.operand_stack.push(global_.valtype)
+
+
+def validate_set_global(instruction: GlobalOp, context: Context) -> None:
+    context.validate_global_idx(instruction.global_idx)
+    global_ = context.get_global(instruction.global_idx)
+
+    if global_.mut is not Mutability.var:  # type: ignore
+        raise ValidationError(
+            f"Global variable at index {instruction.global_idx} is immutable "
+            "and cannot be modified"
+        )
+
+    context.pop_operand_and_assert_type(global_.valtype)


### PR DESCRIPTION
## What was wrong?

Expression validation was done using one very large nested set of `if/elif/else` blocks.  This made type safety hard and was very hard to read.

## How was it fixed?

Expression validation has been refactored into individual validation functions for each *type*, as well as formalizing the data structures used during validation.

#### Cute Animal Picture

![mj731](https://user-images.githubusercontent.com/824194/52134420-c5afd080-2600-11e9-81a4-beeb3790ce03.jpg)

