### PR TITLE
Piper/todo comment cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# coverage
+htmlcov/**

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -40,7 +40,7 @@ class Function(NamedTuple):
     """
     https://webassembly.github.io/spec/core/bikeshed/index.html#functions%E2%91%A0
     """
-    type: TypeIdx
+    type_idx: TypeIdx
     locals: Tuple[ValType, ...]
     body: Tuple['BaseInstruction', ...]
 


### PR DESCRIPTION
Builds from #50 

## What was wrong?

- Many unaddressed `TODO` comments
- Lots of dead code that isn't tested and won't be used in the `wasm.main` module.

## How was it fixed?

- Deleted any function that wasn't touched during full test run (as measured by `pytest-cov`)
- Looked at each `TODO` and cleaned up the ones that are able to be addressed at this time.

#### Cute Animal Picture

![cone_of_shame_2](https://user-images.githubusercontent.com/824194/52150809-53ee7b80-262e-11e9-8663-a0d8ccebe139.jpg)

