### PR TITLE
Isolate mutation during expression validation

### DIFF
--- a/wasm/instructions/control.py
+++ b/wasm/instructions/control.py
@@ -48,6 +48,18 @@ class Block(NamedTuple):
         rt = f"({','.join((v.value for v in self.result_type))})"
         return f"{self.opcode.text}[rt={rt},expr={stringify_instructions(self.instructions)}]"
 
+    @classmethod
+    def wrap(self,
+             result_type: Tuple[ValType, ...],
+             expression: Tuple[BaseInstruction, ...]
+             ) -> Tuple[BaseInstruction, ...]:
+        return cast(Tuple[BaseInstruction, ...], (
+            Block(
+                result_type,
+                expression,
+            ),
+        ))
+
 
 @register
 class Br(Interned):

--- a/wasm/instructions/control.py
+++ b/wasm/instructions/control.py
@@ -49,12 +49,12 @@ class Block(NamedTuple):
         return f"{self.opcode.text}[rt={rt},expr={stringify_instructions(self.instructions)}]"
 
     @classmethod
-    def wrap(self,
+    def wrap(cls,
              result_type: Tuple[ValType, ...],
              expression: Tuple[BaseInstruction, ...]
              ) -> Tuple[BaseInstruction, ...]:
         return cast(Tuple[BaseInstruction, ...], (
-            Block(
+            cls(
                 result_type,
                 expression,
             ),

--- a/wasm/validation/__init__.py
+++ b/wasm/validation/__init__.py
@@ -1,12 +1,22 @@
 from .context import (  # noqa: F401
     Context,
 )
+from .data_segment import (  # noqa: F401
+    validate_data_segment,
+)
+from .element_segment import (  # noqa: F401
+    validate_element_segment,
+)
 from .expressions import (  # noqa: F401
     validate_constant_expression,
     validate_expression,
 )
 from .function import (  # noqa: F401
     validate_function_type,
+    validate_function,
+)
+from .globals import (  # noqa: F401
+    validate_global,
 )
 from .limits import (  # noqa: F401
     validate_limits,

--- a/wasm/validation/context.py
+++ b/wasm/validation/context.py
@@ -1,4 +1,5 @@
 from typing import (
+    Optional,
     Tuple,
     Union,
 )
@@ -35,119 +36,17 @@ from .unknown import (
 Unknown = _Unkown.Unknown
 
 
-class Context:
-    def __init__(self,
-                 *,
-                 types: Tuple[FunctionType, ...],
-                 functions: Tuple[FunctionType, ...],
-                 tables: Tuple[TableType, ...],
-                 mems: Tuple[MemoryType, ...],
-                 globals: Tuple[GlobalType, ...],
-                 locals: Tuple[ValType, ...],
-                 labels: Tuple[ValType, ...],
-                 # `returns` may be `None`, but the argument must be
-                 # explicitely supplied.
-                 returns: Union[None, Tuple[ValType, ...]],
-                 ) -> None:
-        self.types = types
-        self.functions = functions
-        self.tables = tables
-        self.mems = mems
-        self.globals = globals
-        self.locals = locals
-        self.labels = labels
-        self.returns = returns
-        self.operand_stack = OperandStack()
-        self.control_stack = ControlStack()
-
-    def prime(self,
-              *,
-              types: Tuple[FunctionType, ...] = None,
-              functions: Tuple[FunctionType, ...] = None,
-              tables: Tuple[TableType, ...] = None,
-              mems: Tuple[MemoryType, ...] = None,
-              globals: Tuple[GlobalType, ...] = None,
-              locals: Tuple[ValType, ...] = None,
-              labels: Tuple[ValType, ...] = None,
-              returns: Tuple[ValType, ...] = None) -> 'Context':
-        return type(self)(
-            types=types or self.types,
-            functions=functions or self.functions,
-            tables=tables or self.tables,
-            mems=mems or self.mems,
-            globals=globals or self.globals,
-            locals=locals or self.locals,
-            labels=labels or self.labels,
-            returns=returns or self.returns,
-        )
-
-    #
-    # Opocode Validation
-    #
-    def mark_unreachable(self) -> None:
-        """
-        Mark the current frame as unreachable.
-        """
-        frame = self.control_stack.pop()
-        while len(self.operand_stack) > frame.height:
-            self.operand_stack.pop()
-        self.control_stack.push(frame.mark_unreachable())
-
-    def push_control_frame(self,
-                           label_types: Tuple[ValType, ...],
-                           end_types: Tuple[ValType, ...]) -> None:
-        """
-        Mark the entry into a new control frame (such as encountering a BLOCK or IF instruction)
-        """
-        frame = ControlFrame(label_types, end_types, len(self.operand_stack), False)
-        self.control_stack.push(frame)
-
-    def pop_control_frame(self) -> ControlFrame:
-        try:
-            frame = self.control_stack.peek()
-        except IndexError:
-            raise ValidationError("Attempt to pop from empty control stack")
-
-        self.pop_operands_of_expected_types(frame.end_types)
-
-        if len(self.operand_stack) != frame.height:
-            raise ValidationError(
-                f"Operand stack height invalid.  Expected: {frame.height}  Got: "
-                f"{len(self.operand_stack)}"
-            )
-        return self.control_stack.pop()
-
-    def pop_operand(self) -> Operand:
-        frame = self.control_stack.peek()
-
-        if frame.is_unreachable and len(self.operand_stack) == frame.height:
-            return Unknown
-        elif len(self.operand_stack) <= frame.height:
-            raise ValidationError(
-                f"Underflow: Insufficient operands: {len(self.operand_stack)} <= "
-                f"{frame.height}"
-            )
-        else:
-            return self.operand_stack.pop()
-
-    def pop_operand_and_assert_type(self, expected: Operand) -> Operand:
-        actual = self.pop_operand()
-
-        if actual is Unknown or expected is Unknown:
-            return expected
-        elif actual == expected:
-            return actual
-        else:
-            raise ValidationError(
-                f"Type mismatch on operand stack.  Expected: {expected}  Got: "
-                f"{actual}"
-            )
-
-    def pop_operands_of_expected_types(self,
-                                       expected_types: Tuple[ValType, ...],
-                                       ) -> None:
-        for expected in reversed(expected_types):
-            self.pop_operand_and_assert_type(expected)
+class BaseContext:
+    types: Tuple[FunctionType, ...]
+    functions: Tuple[FunctionType, ...]
+    tables: Tuple[TableType, ...]
+    mems: Tuple[MemoryType, ...]
+    globals: Tuple[GlobalType, ...]
+    locals: Tuple[ValType, ...]
+    labels: Tuple[ValType, ...]
+    # `returns` may be `None`, but the argument must be
+    # explicitely supplied.
+    returns: Union[None, Tuple[ValType, ...]]
 
     #
     # Types
@@ -238,3 +137,216 @@ class Context:
 
     def get_local(self, idx: LocalIdx) -> ValType:
         return self.locals[idx]
+
+
+class Context(BaseContext):
+    def __init__(self,
+                 *,
+                 types: Tuple[FunctionType, ...],
+                 functions: Tuple[FunctionType, ...],
+                 tables: Tuple[TableType, ...],
+                 mems: Tuple[MemoryType, ...],
+                 globals: Tuple[GlobalType, ...],
+                 locals: Tuple[ValType, ...],
+                 labels: Tuple[ValType, ...],
+                 # `returns` may be `None`, but the argument must be
+                 # explicitely supplied.
+                 returns: Union[None, Tuple[ValType, ...]],
+                 ) -> None:
+        self.types = types
+        self.functions = functions
+        self.tables = tables
+        self.mems = mems
+        self.globals = globals
+        self.locals = locals
+        self.labels = labels
+        self.returns = returns
+
+    def copy(self,
+             *,
+             types: Tuple[FunctionType, ...] = None,
+             functions: Tuple[FunctionType, ...] = None,
+             tables: Tuple[TableType, ...] = None,
+             mems: Tuple[MemoryType, ...] = None,
+             globals: Tuple[GlobalType, ...] = None,
+             locals: Tuple[ValType, ...] = None,
+             labels: Tuple[ValType, ...] = None,
+             returns: Tuple[ValType, ...] = None) -> 'Context':
+        return type(self)(
+            types=types or self.types,
+            functions=functions or self.functions,
+            tables=tables or self.tables,
+            mems=mems or self.mems,
+            globals=globals or self.globals,
+            locals=locals or self.locals,
+            labels=labels or self.labels,
+            returns=returns or self.returns,
+        )
+
+    def expression_context(self,
+                           *,
+                           types: Tuple[FunctionType, ...] = None,
+                           functions: Tuple[FunctionType, ...] = None,
+                           tables: Tuple[TableType, ...] = None,
+                           mems: Tuple[MemoryType, ...] = None,
+                           globals: Tuple[GlobalType, ...] = None,
+                           locals: Tuple[ValType, ...] = None,
+                           labels: Tuple[ValType, ...] = None,
+                           returns: Tuple[ValType, ...] = None) -> 'ExpressionContext':
+        context = self.copy(
+            types=types,
+            functions=functions,
+            tables=tables,
+            mems=mems,
+            globals=globals,
+            locals=locals,
+            labels=labels,
+            returns=returns,
+        )
+        return ExpressionContext(context)
+
+
+class ExpressionContext(BaseContext):
+    _operand_stack: Optional[OperandStack]
+    _control_stack: Optional[ControlStack]
+    _result_type: Optional[Tuple[ValType, ...]] = None
+
+    def __init__(self, context: Context) -> None:
+        self.is_final = False
+        self._operand_stack = OperandStack()
+        self._control_stack = ControlStack()
+
+        # context properties
+        self.types = context.types
+        self.functions = context.functions
+        self.tables = context.tables
+        self.mems = context.mems
+        self.globals = context.globals
+        self.locals = context.locals
+        self.labels = context.labels
+        self.returns = context.returns
+
+    #
+    # Validation data structures
+    #
+    @property
+    def operand_stack(self) -> OperandStack:
+        if self._operand_stack is None:
+            raise AttributeError(
+                "The `operand_stack` is not available on a finialized "
+                "ExpressionContext"
+            )
+        return self._operand_stack
+
+    @property
+    def control_stack(self) -> ControlStack:
+        if self._control_stack is None:
+            raise AttributeError(
+                "The `control_stack` is not available on a finialized "
+                "ExpressionContext"
+            )
+        return self._control_stack
+
+    @property
+    def result_type(self) -> Tuple[ValType, ...]:
+        if not self.is_final:
+            raise AttributeError(
+                "Result type is not available until the `ExpressionContext` has "
+                "been finalized."
+            )
+        elif self._result_type is None:
+            raise Exception("Invariant")
+        else:
+            return self._result_type
+
+    #
+    # Context manager API
+    #
+    def __enter__(self) -> 'ExpressionContext':
+        if self.is_final:
+            raise ValidationError(
+                "This `ExpressionContext` has already been finalized."
+            )
+        return self
+
+    def __exit__(self, exc_type: None, exc_value: None, traceback: None) -> None:
+        if exc_type is None:
+            self._decomission()
+
+    def _decomission(self) -> None:
+        if self.is_final:
+            raise ValidationError(
+                "This `ExpressionContext` has already been finalized."
+            )
+        self._result_type = tuple(self.operand_stack)
+        self._operand_stack = None
+        self._control_stack = None
+        self.is_final = True
+
+    #
+    # Validation API
+    #
+    def mark_unreachable(self) -> None:
+        """
+        Mark the current frame as unreachable.
+        """
+        frame = self.control_stack.pop()
+        while len(self.operand_stack) > frame.height:
+            self.operand_stack.pop()
+        self.control_stack.push(frame.mark_unreachable())
+
+    def push_control_frame(self,
+                           label_types: Tuple[ValType, ...],
+                           end_types: Tuple[ValType, ...]) -> None:
+        """
+        Mark the entry into a new control frame (such as encountering a BLOCK or IF instruction)
+        """
+        frame = ControlFrame(label_types, end_types, len(self.operand_stack), False)
+        self.control_stack.push(frame)
+
+    def pop_control_frame(self) -> ControlFrame:
+        try:
+            frame = self.control_stack.peek()
+        except IndexError:
+            raise ValidationError("Attempt to pop from empty control stack")
+
+        self.pop_operands_of_expected_types(frame.end_types)
+
+        if len(self.operand_stack) != frame.height:
+            raise ValidationError(
+                f"Operand stack height invalid.  Expected: {frame.height}  Got: "
+                f"{len(self.operand_stack)}"
+            )
+        return self.control_stack.pop()
+
+    def pop_operand(self) -> Operand:
+        frame = self.control_stack.peek()
+
+        if frame.is_unreachable and len(self.operand_stack) == frame.height:
+            return Unknown
+        elif len(self.operand_stack) <= frame.height:
+            raise ValidationError(
+                f"Underflow: Insufficient operands: {len(self.operand_stack)} <= "
+                f"{frame.height}"
+            )
+        else:
+            return self.operand_stack.pop()
+
+    def pop_operand_and_assert_type(self, expected: Operand) -> Operand:
+        actual = self.pop_operand()
+
+        if actual is Unknown or expected is Unknown:
+            return expected
+        elif actual == expected:
+            return actual
+        else:
+            raise ValidationError(
+                f"Type mismatch on operand stack.  Expected: {expected}  Got: "
+                f"{actual}"
+            )
+
+    def pop_operands_of_expected_types(self,
+                                       expected_types: Tuple[ValType, ...],
+                                       ) -> None:
+        for expected in reversed(expected_types):
+            self.pop_operand_and_assert_type(expected)

--- a/wasm/validation/control.py
+++ b/wasm/validation/control.py
@@ -26,101 +26,101 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 
 
-def validate_control_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_control_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode is BinaryOpcode.UNREACHABLE:
-        validate_unreachable(context)
+        validate_unreachable(ctx)
     elif instruction.opcode is BinaryOpcode.BLOCK:
-        validate_block(cast(Block, instruction), context)
+        validate_block(cast(Block, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.END:
-        validate_end(context)
+        validate_end(ctx)
     elif instruction.opcode is BinaryOpcode.IF:
-        validate_if(cast(If, instruction), context)
+        validate_if(cast(If, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.ELSE:
-        validate_else(cast(Else, instruction), context)
+        validate_else(cast(Else, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.LOOP:
-        validate_loop(cast(Loop, instruction), context)
+        validate_loop(cast(Loop, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.BR:
-        validate_br(cast(Br, instruction), context)
+        validate_br(cast(Br, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.BR_IF:
-        validate_br_if(cast(BrIf, instruction), context)
+        validate_br_if(cast(BrIf, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.BR_TABLE:
-        validate_br_table(cast(BrTable, instruction), context)
+        validate_br_table(cast(BrTable, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.NOP:
         pass  # NOP is always valid
     elif instruction.opcode is BinaryOpcode.CALL:
-        validate_call(cast(Call, instruction), context)
+        validate_call(cast(Call, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.CALL_INDIRECT:
-        validate_call_indirect(cast(CallIndirect, instruction), context)
+        validate_call_indirect(cast(CallIndirect, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.RETURN:
-        validate_return(context)
+        validate_return(ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_unreachable(context: Context) -> None:
-    context.mark_unreachable()
+def validate_unreachable(ctx: ExpressionContext) -> None:
+    ctx.mark_unreachable()
 
 
-def validate_block(instruction: Block, context: Context) -> None:
-    context.push_control_frame(instruction.result_type, instruction.result_type)
+def validate_block(instruction: Block, ctx: ExpressionContext) -> None:
+    ctx.push_control_frame(instruction.result_type, instruction.result_type)
 
 
-def validate_if(instruction: If, context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.push_control_frame(instruction.result_type, instruction.result_type)
+def validate_if(instruction: If, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.push_control_frame(instruction.result_type, instruction.result_type)
 
 
-def validate_else(instruction: Else, context: Context) -> None:
-    frame = context.pop_control_frame()
-    context.push_control_frame(frame.end_types, frame.end_types)
+def validate_else(instruction: Else, ctx: ExpressionContext) -> None:
+    frame = ctx.pop_control_frame()
+    ctx.push_control_frame(frame.end_types, frame.end_types)
 
 
-def validate_br_if(instruction: BrIf, context: Context) -> None:
-    context.control_stack.validate_label_idx(instruction.label_idx)
+def validate_br_if(instruction: BrIf, ctx: ExpressionContext) -> None:
+    ctx.control_stack.validate_label_idx(instruction.label_idx)
 
-    frame = context.control_stack.get_by_label_idx(instruction.label_idx)
+    frame = ctx.control_stack.get_by_label_idx(instruction.label_idx)
     label_types = frame.label_types
 
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.pop_operands_of_expected_types(label_types)
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.pop_operands_of_expected_types(label_types)
 
     for valtype in label_types:
-        context.operand_stack.push(valtype)
+        ctx.operand_stack.push(valtype)
 
 
-def validate_end(context: Context) -> None:
-    frame = context.pop_control_frame()
+def validate_end(ctx: ExpressionContext) -> None:
+    frame = ctx.pop_control_frame()
     for valtype in frame.end_types:
-        context.operand_stack.push(valtype)
+        ctx.operand_stack.push(valtype)
 
 
-def validate_loop(instruction: Loop, context: Context) -> None:
-    context.push_control_frame(tuple(), instruction.result_type)
+def validate_loop(instruction: Loop, ctx: ExpressionContext) -> None:
+    ctx.push_control_frame(tuple(), instruction.result_type)
 
 
-def validate_br(instruction: Br, context: Context) -> None:
-    context.control_stack.validate_label_idx(instruction.label_idx)
+def validate_br(instruction: Br, ctx: ExpressionContext) -> None:
+    ctx.control_stack.validate_label_idx(instruction.label_idx)
 
-    frame = context.control_stack.get_by_label_idx(instruction.label_idx)
+    frame = ctx.control_stack.get_by_label_idx(instruction.label_idx)
     expected_label_types = frame.label_types
 
-    context.pop_operands_of_expected_types(expected_label_types)
-    context.mark_unreachable()
+    ctx.pop_operands_of_expected_types(expected_label_types)
+    ctx.mark_unreachable()
 
 
-def validate_br_table(instruction: BrTable, context: Context) -> None:
-    context.control_stack.validate_label_idx(instruction.default_idx)
+def validate_br_table(instruction: BrTable, ctx: ExpressionContext) -> None:
+    ctx.control_stack.validate_label_idx(instruction.default_idx)
 
-    frame = context.control_stack.get_by_label_idx(instruction.default_idx)
+    frame = ctx.control_stack.get_by_label_idx(instruction.default_idx)
     expected_label_types = frame.label_types
 
     for idx, label_idx in enumerate(instruction.label_indices):
-        context.control_stack.validate_label_idx(label_idx)
-        label_frame = context.control_stack.get_by_label_idx(label_idx)
+        ctx.control_stack.validate_label_idx(label_idx)
+        label_frame = ctx.control_stack.get_by_label_idx(label_idx)
 
         if label_frame.label_types != expected_label_types:
             raise ValidationError(
@@ -128,33 +128,33 @@ def validate_br_table(instruction: BrTable, context: Context) -> None:
                 f"{expected_label_types}  Got: {label_frame.label_types}"
             )
 
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.pop_operands_of_expected_types(expected_label_types)
-    context.mark_unreachable()
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.pop_operands_of_expected_types(expected_label_types)
+    ctx.mark_unreachable()
 
 
-def validate_call(instruction: Call, context: Context) -> None:
-    context.validate_function_idx(instruction.func_idx)
-    function_type = context.get_function(instruction.func_idx)
+def validate_call(instruction: Call, ctx: ExpressionContext) -> None:
+    ctx.validate_function_idx(instruction.func_idx)
+    function_type = ctx.get_function(instruction.func_idx)
 
-    context.pop_operands_of_expected_types(function_type.params)
+    ctx.pop_operands_of_expected_types(function_type.params)
     for valtype in function_type.results:
-        context.operand_stack.push(valtype)
+        ctx.operand_stack.push(valtype)
 
 
-def validate_call_indirect(instruction: CallIndirect, context: Context) -> None:
-    context.validate_table_idx(TableIdx(0))
-    context.validate_type_idx(instruction.type_idx)
-    function_type = context.get_type(instruction.type_idx)
+def validate_call_indirect(instruction: CallIndirect, ctx: ExpressionContext) -> None:
+    ctx.validate_table_idx(TableIdx(0))
+    ctx.validate_type_idx(instruction.type_idx)
+    function_type = ctx.get_type(instruction.type_idx)
 
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.pop_operands_of_expected_types(function_type.params)
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.pop_operands_of_expected_types(function_type.params)
 
     for valtype in function_type.results:
-        context.operand_stack.push(valtype)
+        ctx.operand_stack.push(valtype)
 
 
-def validate_return(context: Context) -> None:
-    if context.returns is not None:
-        context.pop_operands_of_expected_types(context.returns)
-    context.mark_unreachable()
+def validate_return(ctx: ExpressionContext) -> None:
+    if ctx.returns is not None:
+        ctx.pop_operands_of_expected_types(ctx.returns)
+    ctx.mark_unreachable()

--- a/wasm/validation/data_segment.py
+++ b/wasm/validation/data_segment.py
@@ -1,0 +1,38 @@
+from wasm.datatypes import (
+    DataSegment,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    Block,
+)
+
+from .context import (
+    Context,
+)
+from .expressions import (
+    validate_constant_expression,
+    validate_expression,
+)
+
+
+def validate_data_segment(context: Context, data_segment: DataSegment) -> None:
+    context.validate_mem_idx(data_segment.mem_idx)
+
+    expected_result_type = (ValType.i32,)
+    with context.expression_context() as ctx:
+        expression = Block.wrap(expected_result_type, data_segment.offset)
+        validate_expression(expression, ctx)
+
+    result_type = ctx.result_type
+
+    if result_type != expected_result_type:
+        raise ValidationError(
+            f"Invalid data segment.  Return type must be '(i32,)'.  Got "
+            f"{result_type}"
+        )
+
+    with context.expression_context() as ctx:
+        validate_constant_expression(data_segment.offset, ctx)

--- a/wasm/validation/element_segment.py
+++ b/wasm/validation/element_segment.py
@@ -1,0 +1,50 @@
+from wasm.datatypes import (
+    ElementSegment,
+    FunctionAddress,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    Block,
+)
+
+from .context import (
+    Context,
+)
+from .expressions import (
+    validate_constant_expression,
+    validate_expression,
+)
+
+
+def validate_element_segment(context: Context, element_segment: ElementSegment) -> None:
+    context.validate_table_idx(element_segment.table_idx)
+    table_type = context.get_table(element_segment.table_idx)
+
+    elem_type = table_type.elem_type
+    if elem_type is not FunctionAddress:
+        raise ValidationError(
+            f"Table has invalid element type.  Expected `FunctionAddress`. "
+            f"Got: `{elem_type}`"
+        )
+
+    expected_result_type = (ValType.i32,)
+    with context.expression_context() as ctx:
+        expression = Block.wrap(expected_result_type, element_segment.offset)
+        validate_expression(expression, ctx)
+
+    result_type = ctx.result_type
+
+    if result_type != expected_result_type:
+        raise ValidationError(
+            f"Invalid data segment.  Return type must be '(i32,)'.  Got "
+            f"{result_type}"
+        )
+
+    with context.expression_context() as ctx:
+        validate_constant_expression(element_segment.offset, ctx)
+
+    for function_idx in element_segment.init:
+        context.validate_function_idx(function_idx)

--- a/wasm/validation/function.py
+++ b/wasm/validation/function.py
@@ -1,6 +1,5 @@
 from typing import (
     Tuple,
-    cast,
 )
 
 from wasm.datatypes import (
@@ -12,7 +11,6 @@ from wasm.exceptions import (
     ValidationError,
 )
 from wasm.instructions import (
-    BaseInstruction,
     Block,
 )
 
@@ -44,13 +42,8 @@ def validate_function(context: Context,
     )
     with ctx:
         # validate body using algorithm in appendix
-        instrstar = cast(Tuple[BaseInstruction, ...], (
-            Block(
-                function_type.results,
-                function.body,
-            ),
-        ))
-        validate_expression(instrstar, ctx)
+        expression = Block.wrap(function_type.results, function.body)
+        validate_expression(expression, ctx)
 
     result_type = ctx.result_type
     if result_type != expected_result_type:

--- a/wasm/validation/function.py
+++ b/wasm/validation/function.py
@@ -1,8 +1,26 @@
+from typing import (
+    Tuple,
+    cast,
+)
+
 from wasm.datatypes import (
+    Function,
     FunctionType,
+    ValType,
 )
 from wasm.exceptions import (
     ValidationError,
+)
+from wasm.instructions import (
+    BaseInstruction,
+    Block,
+)
+
+from .context import (
+    Context,
+)
+from .expressions import (
+    validate_expression,
 )
 
 
@@ -10,4 +28,33 @@ def validate_function_type(function_type: FunctionType) -> None:
     if len(function_type.results) > 1:
         raise ValidationError(
             f"Function types may only have one result.  Got {len(function_type.results)}"
+        )
+
+
+def validate_function(context: Context,
+                      function: Function,
+                      expected_result_type: Tuple[ValType, ...]) -> None:
+    context.validate_type_idx(function.type_idx)
+    function_type = context.get_type(function.type_idx)
+
+    ctx = context.expression_context(
+        locals=tuple(function_type.params + function.locals),
+        labels=function_type.results,
+        returns=function_type.results,
+    )
+    with ctx:
+        # validate body using algorithm in appendix
+        instrstar = cast(Tuple[BaseInstruction, ...], (
+            Block(
+                function_type.results,
+                function.body,
+            ),
+        ))
+        validate_expression(instrstar, ctx)
+
+    result_type = ctx.result_type
+    if result_type != expected_result_type:
+        raise ValidationError(
+            f"Function result type does not match declared result type: "
+            f"{result_type} != {expected_result_type}"
         )

--- a/wasm/validation/globals.py
+++ b/wasm/validation/globals.py
@@ -1,0 +1,36 @@
+from wasm.datatypes import (
+    Global,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.instructions import (
+    Block,
+)
+
+from .context import (
+    Context,
+)
+from .expressions import (
+    validate_constant_expression,
+    validate_expression,
+)
+
+
+def validate_global(context: Context, global_: Global) -> None:
+    expected_result_type = (global_.type.valtype,)
+
+    with context.expression_context() as ctx:
+        expression = Block.wrap((global_.type.valtype,), global_.init)
+        validate_expression(expression, ctx)
+
+    result_type = ctx.result_type
+
+    if result_type != expected_result_type:
+        raise ValidationError(
+            f"Initialization code fro global variable result type does not "
+            f"match global value type: {result_type} != {expected_result_type}"
+        )
+
+    with context.expression_context() as ctx:
+        validate_constant_expression(global_.init, ctx)

--- a/wasm/validation/instructions.py
+++ b/wasm/validation/instructions.py
@@ -17,7 +17,7 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 from .control import (
     validate_control_instruction,
@@ -39,33 +39,33 @@ from .variable import (
 )
 
 
-def validate_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode.is_control:
-        validate_control_instruction(instruction, context)
+        validate_control_instruction(instruction, ctx)
     elif instruction.opcode.is_variable:
-        validate_variable_instruction(instruction, context)
+        validate_variable_instruction(instruction, ctx)
     elif instruction.opcode.is_memory:
-        validate_memory_instruction(instruction, context)
+        validate_memory_instruction(instruction, ctx)
     elif instruction.opcode.is_parametric:
-        validate_parametric_instruction(instruction, context)
+        validate_parametric_instruction(instruction, ctx)
     elif instruction.opcode.is_numeric:
-        validate_numeric_instruction(instruction, context)
+        validate_numeric_instruction(instruction, ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_constant_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_constant_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode is BinaryOpcode.GET_GLOBAL:
-        global_ = context.get_global(cast(GlobalOp, instruction).global_idx)
+        global_ = ctx.get_global(cast(GlobalOp, instruction).global_idx)
 
         if global_.mut is not Mutability.const:
             raise ValidationError(
                 "Attempt to access mutable global variable within constant "
                 "expression"
             )
-        validate_get_global(cast(GlobalOp, instruction), context)
+        validate_get_global(cast(GlobalOp, instruction), ctx)
     elif instruction.opcode.is_numeric_constant:
-        validate_numeric_constant(cast(TNumericConstant, instruction), context)
+        validate_numeric_constant(cast(TNumericConstant, instruction), ctx)
     else:
         raise ValidationError(
             "Illegal instruction.  Only "

--- a/wasm/validation/memory.py
+++ b/wasm/validation/memory.py
@@ -24,7 +24,7 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 from .limits import (
     validate_limits,
@@ -40,49 +40,49 @@ def validate_memory(memory: Memory) -> None:
     validate_memory_type(memory.type)
 
 
-def validate_memory_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_memory_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode.is_memory_load:
-        validate_memory_load(cast(MemoryOp, instruction), context)
+        validate_memory_load(cast(MemoryOp, instruction), ctx)
     elif instruction.opcode.is_memory_store:
-        validate_memory_store(cast(MemoryOp, instruction), context)
+        validate_memory_store(cast(MemoryOp, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.MEMORY_SIZE:
-        validate_memory_size(context)
+        validate_memory_size(ctx)
     elif instruction.opcode is BinaryOpcode.MEMORY_GROW:
-        validate_memory_grow(context)
+        validate_memory_grow(ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_memory_load(instruction: MemoryOp, context: Context) -> None:
-    context.validate_mem_idx(MemoryIdx(0))
+def validate_memory_load(instruction: MemoryOp, ctx: ExpressionContext) -> None:
+    ctx.validate_mem_idx(MemoryIdx(0))
 
     align_ceil = instruction.memory_bit_size.value // 8
     if 2 ** instruction.memarg.align > align_ceil:
         raise ValidationError("Invalid memarg alignment")
 
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.operand_stack.push(instruction.valtype)
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_memory_store(instruction: MemoryOp, context: Context) -> None:
-    context.validate_mem_idx(MemoryIdx(0))
+def validate_memory_store(instruction: MemoryOp, ctx: ExpressionContext) -> None:
+    ctx.validate_mem_idx(MemoryIdx(0))
 
     align_ceil = instruction.memory_bit_size.value // 8
     if 2 ** instruction.memarg.align > align_ceil:
         raise ValidationError("Invalid memarg alignment")
 
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.pop_operand_and_assert_type(ValType.i32)
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.pop_operand_and_assert_type(ValType.i32)
 
 
-def validate_memory_size(context: Context) -> None:
-    context.validate_mem_idx(MemoryIdx(0))
+def validate_memory_size(ctx: ExpressionContext) -> None:
+    ctx.validate_mem_idx(MemoryIdx(0))
 
-    context.operand_stack.push(ValType.i32)
+    ctx.operand_stack.push(ValType.i32)
 
 
-def validate_memory_grow(context: Context) -> None:
-    context.validate_mem_idx(MemoryIdx(0))
+def validate_memory_grow(ctx: ExpressionContext) -> None:
+    ctx.validate_mem_idx(MemoryIdx(0))
 
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.operand_stack.push(ValType.i32)
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.operand_stack.push(ValType.i32)

--- a/wasm/validation/numeric.py
+++ b/wasm/validation/numeric.py
@@ -26,105 +26,105 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 
 TNumericConstant = Union[I32Const, I64Const, F32Const, F64Const]
 TConversion = Union[Wrap, Truncate, Convert, Reinterpret]
 
 
-def validate_numeric_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_numeric_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode.is_numeric_constant:
-        validate_numeric_constant(cast(TNumericConstant, instruction), context)
+        validate_numeric_constant(cast(TNumericConstant, instruction), ctx)
     elif instruction.opcode.is_relop:
-        validate_relop(cast(RelOp, instruction), context)
+        validate_relop(cast(RelOp, instruction), ctx)
     elif instruction.opcode.is_unop:
-        validate_unop(cast(UnOp, instruction), context)
+        validate_unop(cast(UnOp, instruction), ctx)
     elif instruction.opcode.is_binop:
-        validate_binop(cast(BinOp, instruction), context)
+        validate_binop(cast(BinOp, instruction), ctx)
     elif instruction.opcode.is_testop:
-        validate_testop(cast(TestOp, instruction), context)
+        validate_testop(cast(TestOp, instruction), ctx)
     elif instruction.opcode.is_conversion:
-        validate_conversion(cast(TConversion, instruction), context)
+        validate_conversion(cast(TConversion, instruction), ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_numeric_constant(instruction: TNumericConstant, context: Context) -> None:
-    context.operand_stack.push(instruction.valtype)
+def validate_numeric_constant(instruction: TNumericConstant, ctx: ExpressionContext) -> None:
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_relop(instruction: RelOp, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.operand_stack.push(ValType.i32)
+def validate_relop(instruction: RelOp, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.operand_stack.push(ValType.i32)
 
 
-def validate_unop(instruction: UnOp, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.operand_stack.push(instruction.valtype)
+def validate_unop(instruction: UnOp, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_binop(instruction: BinOp, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.operand_stack.push(instruction.valtype)
+def validate_binop(instruction: BinOp, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_testop(instruction: TestOp, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.valtype)
-    context.operand_stack.push(ValType.i32)
+def validate_testop(instruction: TestOp, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.valtype)
+    ctx.operand_stack.push(ValType.i32)
 
 
-def validate_conversion(instruction: TConversion, context: Context) -> None:
+def validate_conversion(instruction: TConversion, ctx: ExpressionContext) -> None:
     if instruction.opcode is BinaryOpcode.I32_WRAP_I64:
-        validate_wrap(context)
+        validate_wrap(ctx)
     elif instruction.opcode in {BinaryOpcode.I64_EXTEND_S_I32, BinaryOpcode.I64_EXTEND_U_I32}:
-        validate_extend(context)
+        validate_extend(ctx)
     elif instruction.opcode.is_truncate:
-        validate_truncate(cast(Truncate, instruction), context)
+        validate_truncate(cast(Truncate, instruction), ctx)
     elif instruction.opcode.is_convert:
-        validate_convert(cast(Convert, instruction), context)
+        validate_convert(cast(Convert, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.F64_PROMOTE_F32:
-        validate_promote(context)
+        validate_promote(ctx)
     elif instruction.opcode is BinaryOpcode.F32_DEMOTE_F64:
-        validate_demote(context)
+        validate_demote(ctx)
     elif instruction.opcode.is_reinterpret:
-        validate_reinterpret(cast(Reinterpret, instruction), context)
+        validate_reinterpret(cast(Reinterpret, instruction), ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_wrap(context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.i64)
-    context.operand_stack.push(ValType.i32)
+def validate_wrap(ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.i64)
+    ctx.operand_stack.push(ValType.i32)
 
 
-def validate_extend(context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.i32)
-    context.operand_stack.push(ValType.i64)
+def validate_extend(ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    ctx.operand_stack.push(ValType.i64)
 
 
-def validate_truncate(instruction: Truncate, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.result)
-    context.operand_stack.push(instruction.valtype)
+def validate_truncate(instruction: Truncate, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_convert(instruction: Convert, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.result)
-    context.operand_stack.push(instruction.valtype)
+def validate_convert(instruction: Convert, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.operand_stack.push(instruction.valtype)
 
 
-def validate_promote(context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.f32)
-    context.operand_stack.push(ValType.f64)
+def validate_promote(ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.f32)
+    ctx.operand_stack.push(ValType.f64)
 
 
-def validate_demote(context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.f64)
-    context.operand_stack.push(ValType.f32)
+def validate_demote(ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.f64)
+    ctx.operand_stack.push(ValType.f32)
 
 
-def validate_reinterpret(instruction: Reinterpret, context: Context) -> None:
-    context.pop_operand_and_assert_type(instruction.result)
-    context.operand_stack.push(instruction.valtype)
+def validate_reinterpret(instruction: Reinterpret, ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.operand_stack.push(instruction.valtype)

--- a/wasm/validation/parametric.py
+++ b/wasm/validation/parametric.py
@@ -9,28 +9,28 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 
 
 #
 # Parametric Instructions
 #
-def validate_parametric_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_parametric_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode is BinaryOpcode.DROP:
-        validate_drop(context)
+        validate_drop(ctx)
     elif instruction.opcode is BinaryOpcode.SELECT:
-        validate_select(context)
+        validate_select(ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_drop(context: Context) -> None:
-    context.pop_operand()
+def validate_drop(ctx: ExpressionContext) -> None:
+    ctx.pop_operand()
 
 
-def validate_select(context: Context) -> None:
-    context.pop_operand_and_assert_type(ValType.i32)
-    valtype = context.pop_operand()
-    context.pop_operand_and_assert_type(valtype)
-    context.operand_stack.push(valtype)
+def validate_select(ctx: ExpressionContext) -> None:
+    ctx.pop_operand_and_assert_type(ValType.i32)
+    valtype = ctx.pop_operand()
+    ctx.pop_operand_and_assert_type(valtype)
+    ctx.operand_stack.push(valtype)

--- a/wasm/validation/variable.py
+++ b/wasm/validation/variable.py
@@ -18,56 +18,56 @@ from wasm.opcodes import (
 )
 
 from .context import (
-    Context,
+    ExpressionContext,
 )
 
 
 #
 # Variable Instructions
 #
-def validate_variable_instruction(instruction: BaseInstruction, context: Context) -> None:
+def validate_variable_instruction(instruction: BaseInstruction, ctx: ExpressionContext) -> None:
     if instruction.opcode is BinaryOpcode.GET_LOCAL:
-        validate_get_local(cast(LocalOp, instruction), context)
+        validate_get_local(cast(LocalOp, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.SET_LOCAL:
-        validate_set_local(cast(LocalOp, instruction), context)
+        validate_set_local(cast(LocalOp, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.TEE_LOCAL:
-        validate_tee_local(cast(LocalOp, instruction), context)
+        validate_tee_local(cast(LocalOp, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.GET_GLOBAL:
-        validate_get_global(cast(GlobalOp, instruction), context)
+        validate_get_global(cast(GlobalOp, instruction), ctx)
     elif instruction.opcode is BinaryOpcode.SET_GLOBAL:
-        validate_set_global(cast(GlobalOp, instruction), context)
+        validate_set_global(cast(GlobalOp, instruction), ctx)
     else:
         raise Exception(f"Invariant: unhandled opcode {instruction.opcode}")
 
 
-def validate_get_local(instruction: LocalOp, context: Context) -> None:
-    context.validate_local_idx(instruction.local_idx)
-    valtype = context.get_local(instruction.local_idx)
-    context.operand_stack.push(valtype)
+def validate_get_local(instruction: LocalOp, ctx: ExpressionContext) -> None:
+    ctx.validate_local_idx(instruction.local_idx)
+    valtype = ctx.get_local(instruction.local_idx)
+    ctx.operand_stack.push(valtype)
 
 
-def validate_set_local(instruction: LocalOp, context: Context) -> None:
-    context.validate_local_idx(instruction.local_idx)
-    valtype = context.get_local(instruction.local_idx)
-    context.pop_operand_and_assert_type(valtype)
+def validate_set_local(instruction: LocalOp, ctx: ExpressionContext) -> None:
+    ctx.validate_local_idx(instruction.local_idx)
+    valtype = ctx.get_local(instruction.local_idx)
+    ctx.pop_operand_and_assert_type(valtype)
 
 
-def validate_tee_local(instruction: LocalOp, context: Context) -> None:
-    context.validate_local_idx(instruction.local_idx)
-    valtype = context.get_local(instruction.local_idx)
-    context.pop_operand_and_assert_type(valtype)
-    context.operand_stack.push(valtype)
+def validate_tee_local(instruction: LocalOp, ctx: ExpressionContext) -> None:
+    ctx.validate_local_idx(instruction.local_idx)
+    valtype = ctx.get_local(instruction.local_idx)
+    ctx.pop_operand_and_assert_type(valtype)
+    ctx.operand_stack.push(valtype)
 
 
-def validate_get_global(instruction: GlobalOp, context: Context) -> None:
-    context.validate_global_idx(instruction.global_idx)
-    global_ = context.get_global(instruction.global_idx)
-    context.operand_stack.push(global_.valtype)
+def validate_get_global(instruction: GlobalOp, ctx: ExpressionContext) -> None:
+    ctx.validate_global_idx(instruction.global_idx)
+    global_ = ctx.get_global(instruction.global_idx)
+    ctx.operand_stack.push(global_.valtype)
 
 
-def validate_set_global(instruction: GlobalOp, context: Context) -> None:
-    context.validate_global_idx(instruction.global_idx)
-    global_ = context.get_global(instruction.global_idx)
+def validate_set_global(instruction: GlobalOp, ctx: ExpressionContext) -> None:
+    ctx.validate_global_idx(instruction.global_idx)
+    global_ = ctx.get_global(instruction.global_idx)
 
     if global_.mut is not Mutability.var:  # type: ignore
         raise ValidationError(
@@ -75,4 +75,4 @@ def validate_set_global(instruction: GlobalOp, context: Context) -> None:
             "and cannot be modified"
         )
 
-    context.pop_operand_and_assert_type(global_.valtype)
+    ctx.pop_operand_and_assert_type(global_.valtype)


### PR DESCRIPTION
builds on #52 

fixes #54 

## What was wrong?

As described in #54 expression validation involved mutating the `Context` object.  This has some unfortunate ways this can fail.

## How was it fixed?

Adjust API for much stronger encapsulation of the mutable components.

#### Cute Animal Picture

![creative-pet-cones-elizabethan-collars-3__605](https://user-images.githubusercontent.com/824194/52218102-259fb480-2857-11e9-9ded-967f157709b3.jpg)

