### PR TITLE
Normalize object/function/variable names for *function* things.

### DIFF
--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -37,7 +37,7 @@ from .imports import (  # noqa: F401
     Import,
 )
 from .indices import (  # noqa: F401
-    FuncIdx,
+    FunctionIdx,
     GlobalIdx,
     LabelIdx,
     LocalIdx,

--- a/wasm/datatypes/element_segment.py
+++ b/wasm/datatypes/element_segment.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 from .indices import (
-    FuncIdx,
+    FunctionIdx,
     TableIdx,
 )
 
@@ -18,4 +18,4 @@ if TYPE_CHECKING:
 class ElementSegment(NamedTuple):
     table_idx: TableIdx
     offset: Tuple['BaseInstruction', ...]
-    init: Tuple[FuncIdx, ...]
+    init: Tuple[FunctionIdx, ...]

--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -10,7 +10,7 @@ from .addresses import (
     TableAddress,
 )
 from .indices import (
-    FuncIdx,
+    FunctionIdx,
     GlobalIdx,
     MemoryIdx,
     TableIdx,
@@ -22,15 +22,15 @@ class Export(NamedTuple):
     https://webassembly.github.io/spec/core/bikeshed/index.html#memory-types%E2%91%A0
     """
     name: str
-    desc: Union[FuncIdx, GlobalIdx, MemoryIdx, TableIdx]
+    desc: Union[FunctionIdx, GlobalIdx, MemoryIdx, TableIdx]
 
     @property
     def is_function(self):
-        return isinstance(self.desc, FuncIdx)
+        return isinstance(self.desc, FunctionIdx)
 
     @property
-    def func_idx(self) -> FuncIdx:
-        if isinstance(self.desc, FuncIdx):
+    def function_idx(self) -> FunctionIdx:
+        if isinstance(self.desc, FunctionIdx):
             return self.desc
         else:
             raise TypeError(f"Export descriptor of type: {type(self.desc)}")

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -6,7 +6,7 @@ from typing import (
 )
 
 from .indices import (
-    FuncIdx,
+    FunctionIdx,
     TypeIdx,
 )
 from .valtype import (
@@ -58,4 +58,4 @@ class StartFunction(NamedTuple):
     """
     https://webassembly.github.io/spec/core/bikeshed/index.html#syntax-start
     """
-    func_idx: FuncIdx
+    function_idx: FunctionIdx

--- a/wasm/datatypes/indices.py
+++ b/wasm/datatypes/indices.py
@@ -1,4 +1,4 @@
-class FuncIdx(int):
+class FunctionIdx(int):
     pass
 
 

--- a/wasm/instructions/control.py
+++ b/wasm/instructions/control.py
@@ -10,7 +10,7 @@ from wasm._utils.interned import (
     Interned,
 )
 from wasm.datatypes import (
-    FuncIdx,
+    FunctionIdx,
     LabelIdx,
     TypeIdx,
     ValType,
@@ -185,11 +185,11 @@ class Unreachable(SimpleOp):
 class Call(Interned):
     opcode = BinaryOpcode.CALL
 
-    def __init__(self, func_idx: FuncIdx) -> None:
-        self.func_idx = func_idx
+    def __init__(self, function_idx: FunctionIdx) -> None:
+        self.function_idx = function_idx
 
     def __str__(self) -> str:
-        return f"{self.opcode.text}[{self.func_idx}]"
+        return f"{self.opcode.text}[{self.function_idx}]"
 
 
 @register

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -33,7 +33,7 @@ from .blocks import (
     parse_blocktype,
 )
 from .indices import (
-    parse_func_idx,
+    parse_function_idx,
     parse_label_idx,
     parse_type_idx,
 )
@@ -149,8 +149,8 @@ def parse_br_table_instruction(stream: io.BytesIO) -> BrTable:
 
 
 def parse_call_instruction(stream: io.BytesIO) -> Call:
-    func_idx = parse_func_idx(stream)
-    return Call(func_idx)
+    function_idx = parse_function_idx(stream)
+    return Call(function_idx)
 
 
 def parse_call_indirect_instruction(stream: io.BytesIO) -> CallIndirect:

--- a/wasm/parsers/element_segment.py
+++ b/wasm/parsers/element_segment.py
@@ -8,7 +8,7 @@ from .expressions import (
     parse_expression,
 )
 from .indices import (
-    parse_func_idx,
+    parse_function_idx,
     parse_table_idx,
 )
 from .vector import (
@@ -19,5 +19,5 @@ from .vector import (
 def parse_element_segment(stream: io.BytesIO) -> ElementSegment:
     table_idx = parse_table_idx(stream)
     offset = parse_expression(stream)
-    init = parse_vector(parse_func_idx, stream)
+    init = parse_vector(parse_function_idx, stream)
     return ElementSegment(table_idx, offset, init)

--- a/wasm/parsers/exports.py
+++ b/wasm/parsers/exports.py
@@ -5,7 +5,7 @@ from typing import (
 
 from wasm.datatypes import (
     Export,
-    FuncIdx,
+    FunctionIdx,
     GlobalIdx,
     MemoryIdx,
     TableIdx,
@@ -18,7 +18,7 @@ from .byte import (
     parse_single_byte,
 )
 from .indices import (
-    parse_func_idx,
+    parse_function_idx,
     parse_global_idx,
     parse_memory_idx,
     parse_table_idx,
@@ -27,14 +27,14 @@ from .text import (
     parse_text,
 )
 
-TExportDesc = Union[FuncIdx, GlobalIdx, MemoryIdx, TableIdx]
+TExportDesc = Union[FunctionIdx, GlobalIdx, MemoryIdx, TableIdx]
 
 
 def parse_export_descriptor(stream: io.BytesIO) -> TExportDesc:
     flag = parse_single_byte(stream)
 
     if flag == 0x00:
-        return parse_func_idx(stream)
+        return parse_function_idx(stream)
     elif flag == 0x01:
         return parse_table_idx(stream)
     elif flag == 0x02:

--- a/wasm/parsers/functions.py
+++ b/wasm/parsers/functions.py
@@ -12,7 +12,7 @@ from .byte import (
     parse_single_byte,
 )
 from .indices import (
-    parse_func_idx,
+    parse_function_idx,
 )
 from .valtype import (
     parse_valtype,
@@ -37,5 +37,5 @@ def parse_function_type(stream: io.BytesIO) -> FunctionType:
 
 
 def parse_start_function(stream: io.BytesIO) -> StartFunction:
-    function_idx = parse_func_idx(stream)
+    function_idx = parse_function_idx(stream)
     return StartFunction(function_idx)

--- a/wasm/parsers/indices.py
+++ b/wasm/parsers/indices.py
@@ -1,7 +1,7 @@
 import io
 
 from wasm.datatypes import (
-    FuncIdx,
+    FunctionIdx,
     GlobalIdx,
     LabelIdx,
     LocalIdx,
@@ -15,9 +15,9 @@ from .integers import (
 )
 
 
-def parse_func_idx(stream: io.BytesIO) -> FuncIdx:
+def parse_function_idx(stream: io.BytesIO) -> FunctionIdx:
     raw_idx = parse_u32(stream)
-    return FuncIdx(raw_idx)
+    return FunctionIdx(raw_idx)
 
 
 def parse_global_idx(stream: io.BytesIO) -> GlobalIdx:

--- a/wasm/validation/__init__.py
+++ b/wasm/validation/__init__.py
@@ -14,6 +14,7 @@ from .expressions import (  # noqa: F401
 from .function import (  # noqa: F401
     validate_function_type,
     validate_function,
+    validate_start_function,
 )
 from .globals import (  # noqa: F401
     validate_global,

--- a/wasm/validation/context.py
+++ b/wasm/validation/context.py
@@ -5,7 +5,7 @@ from typing import (
 )
 
 from wasm.datatypes import (
-    FuncIdx,
+    FunctionIdx,
     FunctionType,
     GlobalIdx,
     GlobalType,
@@ -66,16 +66,16 @@ class BaseContext:
     #
     # Functions
     #
-    def validate_function_idx(self, idx: FuncIdx) -> None:
+    def validate_function_idx(self, idx: FunctionIdx) -> None:
         if not self.has_function(idx):
             raise ValidationError(
                 f"Function index outside of valid range: {idx} >= {len(self.functions)}"
             )
 
-    def has_function(self, idx: FuncIdx) -> bool:
+    def has_function(self, idx: FunctionIdx) -> bool:
         return idx < len(self.functions)
 
-    def get_function(self, idx: FuncIdx) -> FunctionType:
+    def get_function(self, idx: FunctionIdx) -> FunctionType:
         return self.functions[idx]
 
     #

--- a/wasm/validation/control.py
+++ b/wasm/validation/control.py
@@ -134,8 +134,8 @@ def validate_br_table(instruction: BrTable, ctx: ExpressionContext) -> None:
 
 
 def validate_call(instruction: Call, ctx: ExpressionContext) -> None:
-    ctx.validate_function_idx(instruction.func_idx)
-    function_type = ctx.get_function(instruction.func_idx)
+    ctx.validate_function_idx(instruction.function_idx)
+    function_type = ctx.get_function(instruction.function_idx)
 
     ctx.pop_operands_of_expected_types(function_type.params)
     for valtype in function_type.results:

--- a/wasm/validation/function.py
+++ b/wasm/validation/function.py
@@ -5,6 +5,7 @@ from typing import (
 from wasm.datatypes import (
     Function,
     FunctionType,
+    StartFunction,
     ValType,
 )
 from wasm.exceptions import (
@@ -50,4 +51,15 @@ def validate_function(context: Context,
         raise ValidationError(
             f"Function result type does not match declared result type: "
             f"{result_type} != {expected_result_type}"
+        )
+
+
+def validate_start_function(context: Context, start: StartFunction) -> None:
+    context.validate_function_idx(start.function_idx)
+    function_type = context.get_function(start.function_idx)
+
+    if function_type != FunctionType((), ()):
+        raise ValidationError(
+            "Start function may not have arguments or a result type.  Got "
+            f"{function_type}"
         )


### PR DESCRIPTION
Builds on #55

## What was wrong?

The WebAssembly spec uses the name `func` for most references to function *things*.  This is not 100% consistent as things like [start function](https://webassembly.github.io/spec/core/bikeshed/index.html#start-function%E2%91%A0) use the full form.

As the codebase has evolved:

- The `func` abbreviation felt like it was negatively effecting readability.(`func_idx`, `func_addr`, `func_type`, `func`, `hostfunc`
- Cases like the start function use the full form `function`.

While spec conformance by using the name `func` is likely to have some benefits, i.e. easier mapping between the spec and the codebase, I'm not convinced this outweighs the readability improvements that come with using the full form name.  Also, by using the full form name everywhere it became easier to intuitively know what name something would use, where-as before, there was some inconsistency between APIs, such as `Export.is_function` which one might think would be `Export.is_func` if we were using a mix of short-form and long-form.

## How was it fixed?

Converted *almost* all of these to use the long form.  The exceptions which I still plan to cleanup are some of the container types like `Store` and `Module`, both of which still use the short form name.

#### Cute Animal Picture

![cone-of-shame-18-flower](https://user-images.githubusercontent.com/824194/52219089-37825700-2859-11e9-9007-221112a5f5bb.jpg)

