### PR TITLE
caching for opcode.text property

### DIFF
--- a/wasm/opcodes/binary.py
+++ b/wasm/opcodes/binary.py
@@ -337,5 +337,7 @@ class BinaryOpcode(enum.Enum):
 
     @property
     def text(self) -> str:
-        from .text import OPCODE_TO_TEXT
-        return OPCODE_TO_TEXT[self]
+        if not hasattr(self, '_text'):
+            from .text import OPCODE_TO_TEXT
+            self._text = OPCODE_TO_TEXT[self]
+        return self._text


### PR DESCRIPTION
## What was wrong?

The `opcode.text` property involved a bit of lookup overhead.

## How was it fixed?

Cache the value the first time it is accessed.

#### Cute Animal Picture

![382231e5aae0ea9dbf8a2b50a5640961](https://user-images.githubusercontent.com/824194/52438247-15493d00-2ad6-11e9-8677-e3d01af92166.jpg)

