### PR TITLE
signed and unsigned conversion utils and tests

### DIFF
--- a/tests/core/numeric-utils/test_twos_compliment_round_trip.py
+++ b/tests/core/numeric-utils/test_twos_compliment_round_trip.py
@@ -1,0 +1,58 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    s32_to_u32,
+    s64_to_u64,
+    u32_to_s32,
+    u64_to_s64,
+)
+
+
+@given(
+    value=st.integers(
+        min_value=0,
+        max_value=constants.UINT32_MAX,
+    ),
+)
+def test_unsigned32_round_trip(value):
+    actual = s32_to_u32(u32_to_s32(value))
+    assert actual == value
+
+
+@given(
+    value=st.integers(
+        min_value=0,
+        max_value=constants.UINT64_MAX,
+    ),
+)
+def test_unsigned64_round_trip(value):
+    actual = s64_to_u64(u64_to_s64(value))
+    assert actual == value
+
+
+@given(
+    value=st.integers(
+        min_value=constants.SINT32_MIN,
+        max_value=constants.SINT32_MAX,
+    ),
+)
+def test_signed32_round_trip(value):
+    actual = u32_to_s32(s32_to_u32(value))
+    assert actual == value
+
+
+@given(
+    value=st.integers(
+        min_value=constants.SINT64_MIN,
+        max_value=constants.SINT64_MAX,
+    ),
+)
+def test_signed64_round_trip(value):
+    actual = u64_to_s64(s64_to_u64(value))
+    assert actual == value

--- a/tests/core/numeric-utils/test_unsigned_to_signed.py
+++ b/tests/core/numeric-utils/test_unsigned_to_signed.py
@@ -1,0 +1,57 @@
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    u32_to_s32,
+    u64_to_s64,
+)
+
+
+@pytest.mark.parametrize(
+    'convert_fn,value,expected',
+    (
+        (u32_to_s32, 0, 0),
+        (u64_to_s64, 0, 0),
+        (u32_to_s32, 1, 1),
+        (u64_to_s64, 1, 1),
+        (u32_to_s32, constants.SINT32_CEIL, constants.SINT32_MIN),
+        (u64_to_s64, constants.SINT64_CEIL, constants.SINT64_MIN),
+    ),
+)
+def test_unsigned_to_signed(convert_fn, value, expected):
+    actual = convert_fn(value)
+    assert actual == expected
+
+
+@given(
+    value=st.integers(
+        min_value=0,
+        max_value=constants.UINT32_MAX,
+    ),
+)
+def test_unsigned32_to_signed32_fuzz(value):
+    actual = u32_to_s32(value)
+    if value > constants.SINT32_MAX:
+        assert actual < 0
+    else:
+        assert actual == value
+
+
+@given(
+    value=st.integers(
+        min_value=0,
+        max_value=constants.UINT64_MAX,
+    ),
+)
+def test_unsigned64_to_signed64_fuzz(value):
+    actual = u64_to_s64(value)
+    if value > constants.SINT64_MAX:
+        assert actual < 0
+    else:
+        assert actual == value

--- a/wasm/_utils/numeric.py
+++ b/wasm/_utils/numeric.py
@@ -21,3 +21,17 @@ def s64_to_u64(value: SInt64) -> UInt64:
         return UInt64(value + constants.UINT64_CEIL)
     else:
         return UInt64(value)
+
+
+def u32_to_s32(value: UInt32) -> SInt32:
+    if value > constants.SINT32_MAX:
+        return SInt32(value - constants.UINT32_CEIL)
+    else:
+        return SInt32(value)
+
+
+def u64_to_s64(value: UInt64) -> SInt64:
+    if value > constants.SINT64_MAX:
+        return SInt64(value - constants.UINT64_CEIL)
+    else:
+        return SInt64(value)


### PR DESCRIPTION
## What was wrong?

We only had `unsigned > signed` conversions.

## How was it fixed?

Fills out the `signed > signed` and adds round trip hypothesis tests to increase confidence of correctness.

#### Cute Animal Picture

![cone_of_shame_640x4201](https://user-images.githubusercontent.com/824194/52438337-46297200-2ad6-11e9-8ae9-6ba31b841c16.jpg)

