### PR TITLE
ValTyp argument and zero value APIs

### DIFF
--- a/wasm/datatypes/valtype.py
+++ b/wasm/datatypes/valtype.py
@@ -1,7 +1,19 @@
 import enum
+import sys
 
+from wasm import (
+    constants,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
 from wasm.typing import (
+    Float32,
+    Float64,
+    TValue,
     UInt8,
+    UInt32,
+    UInt64,
 )
 
 from .bit_size import (
@@ -101,3 +113,34 @@ class ValType(enum.Enum):
             raise ValueError(
                 f"Invalid bit size.  Must be 32 or 64: Got {num_bits}"
             )
+
+    def validate_arg(self, arg):
+        if self is self.i32:
+            bounds = (0, constants.UINT32_MAX)
+            type_ = int
+        elif self is self.i64:
+            bounds = (0, constants.UINT64_MAX)
+            type_ = int
+        elif self in {self.f32, self.f64}:
+            # TODO: proper bounds
+            bounds = (sys.float_info.min, sys.float_info.max)
+            type_ = float
+        else:
+            raise Exception("Invariant")
+
+        lower, upper = bounds
+        if not isinstance(arg, type_) or arg < lower or arg > upper:
+            raise ValidationError(f"Invalid argument for {self.value}: {arg}")
+
+    @property
+    def zero_value(self) -> TValue:
+        if self is self.i32:
+            return UInt32(0)
+        elif self is self.i64:
+            return UInt64(0)
+        elif self is self.f32:
+            return Float32(0)
+        elif self is self.f64:
+            return Float64(0)
+        else:
+            raise Exception("Invariant")


### PR DESCRIPTION
## What was wrong?

Two APIs that are needed for incoming functionality.

- Ability to validate that a value is appropriate for a given value type.
- Ability to generate the ZERO value for a given value type.

## How was it fixed?

Two new APIs on the `ValType`

- `ValType.zero_value`
- `ValType.validate_arg(value)`

#### Cute Animal Picture

![sadpuppy](https://user-images.githubusercontent.com/824194/52438513-addfbd00-2ad6-11e9-941a-4dc7af4b0343.jpg)
