### PR TITLE
Stack.extend API

### DIFF
--- a/tests/core/test_base_stack_datatype.py
+++ b/tests/core/test_base_stack_datatype.py
@@ -89,3 +89,17 @@ def test_stack_iterable_casting(stack):
     stack.push('c')
 
     assert tuple(stack) == ('a', 'b', 'c')
+
+
+def test_stack_extend(stack):
+    stack.push('a')
+    stack.push('b')
+    stack.push('c')
+    stack.extend(('d', 'e', 'f'))
+
+    assert stack.pop() == 'f'
+    assert stack.pop() == 'e'
+    assert stack.pop() == 'd'
+    assert stack.pop() == 'c'
+    assert stack.pop() == 'b'
+    assert stack.pop() == 'a'

--- a/wasm/stack.py
+++ b/wasm/stack.py
@@ -3,6 +3,7 @@ from collections.abc import (
 )
 from typing import (
     Generic,
+    Iterable,
     Iterator,
     List,
     Tuple,
@@ -58,3 +59,6 @@ class BaseStack(Sequence, Generic[TStackItem]):
 
     def peek(self) -> TStackItem:
         return self._stack[-1]
+
+    def extend(self, values: Iterable[TStackItem]) -> None:
+        self._stack.extend(values)


### PR DESCRIPTION
## What was wrong?

There are multiple places where the following pattern emerges.

```python
values = [config.pop_operand() for _ in range(...)]

...  # do pop a frame or a label

for arg in reversed(values):
    config.push_operand(arg)
```

## How was it fixed?

This allows the loop to be replaced by `config.extend_operands(values)`

#### Cute Animal Picture

![timeout-cone-of-shame-portrait-series8__880](https://user-images.githubusercontent.com/824194/52438703-1e86d980-2ad7-11e9-9abe-251211561871.jpg)
