### PR TITLE
Extend configuration APIs for typed values

### DIFF
--- a/tests/core/execution/test_configuration_object.py
+++ b/tests/core/execution/test_configuration_object.py
@@ -1,0 +1,247 @@
+import pytest
+
+from wasm.datatypes import (
+    Store,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+    Label,
+)
+
+
+@pytest.fixture
+def config():
+    return Configuration(Store())
+
+
+def test_configuration_frame_stack_size(config):
+    assert config.frame_stack_size == 0
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame_stack_size == 1
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame_stack_size == 2
+
+    assert config.pop_frame() is frame_b
+    assert config.pop_frame() is frame_a
+
+    assert config.frame_stack_size == 0
+
+
+def test_configuration_has_active_frame(config):
+    assert config.has_active_frame is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_frame is True
+
+    config.pop_frame()
+
+    assert config.has_active_frame is False
+
+
+def test_configuration_frame_property(config):
+    with pytest.raises(IndexError):
+        config.frame
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame is frame_a
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame is frame_b
+
+    assert config.pop_frame() is frame_b
+
+    assert config.frame is frame_a
+
+
+def test_configuration_has_active_label(config):
+    assert config.has_active_label is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_label is False
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.has_active_label is True
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.has_active_label is False
+
+    # now pop the frame and should have an active label
+    config.pop_frame()
+
+    assert config.has_active_label is True
+
+    config.pop_label()
+
+    assert config.has_active_label is False
+
+
+def test_configuration_active_label_property(config):
+    with pytest.raises(IndexError):
+        config.active_label
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.active_label is label_a
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.active_label is label_b
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.active_label is label_c
+
+
+def test_configuration_instructions_property(config):
+    with pytest.raises(IndexError):
+        config.instructions
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.instructions is frame_a.instructions
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.instructions is label_a.instructions
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.instructions is frame_b.instructions
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.instructions is label_b.instructions
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.instructions is label_c.instructions
+
+
+def test_configuration_push_and_pop_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.operand_stack_size == 0
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.operand_stack_size == 6
+
+    assert config.pop_operand() == 5
+    assert config.operand_stack_size == 5
+    assert config.pop2_operands() == (4, 3)
+    assert config.operand_stack_size == 3
+    assert config.pop3_operands() == (2, 1, 0)
+    assert config.operand_stack_size == 0
+
+
+def test_configuration_push_and_pop_u32_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u32() == 5
+    assert config.pop2_u32() == (4, 3)
+    assert config.pop3_u32() == (2, 1, 0)
+
+
+def test_configuration_push_and_pop_u64_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u64() == 5
+    assert config.pop2_u64() == (4, 3)
+    assert config.pop3_u64() == (2, 1, 0)
+
+
+def test_configuration_get_label_by_idx(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame = Frame(None, [], [], 0)
+    config.push_frame(frame)
+
+    label_3 = Label(0, [], False)
+    config.push_label(label_3)
+    label_2 = Label(0, [], False)
+    config.push_label(label_2)
+    label_1 = Label(0, [], False)
+    config.push_label(label_1)
+    label_0 = Label(0, [], False)
+    config.push_label(label_0)
+
+    assert config.get_by_label_idx(0) is label_0
+    assert config.get_by_label_idx(1) is label_1
+    assert config.get_by_label_idx(2) is label_2
+    assert config.get_by_label_idx(3) is label_3
+
+    with pytest.raises(IndexError):
+        assert config.get_by_label_idx(4)

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -3,7 +3,9 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    Iterable,
     Tuple,
+    cast,
 )
 
 from wasm.datatypes import (
@@ -11,7 +13,10 @@ from wasm.datatypes import (
     Store,
 )
 from wasm.typing import (
+    Float32,
     TValue,
+    UInt32,
+    UInt64,
 )
 
 from .instructions import (
@@ -62,6 +67,17 @@ class BaseConfiguration(ABC):
         pass
 
     #
+    # Results
+    #
+    @abstractmethod
+    def push_result(self, value: TValue) -> None:
+        pass
+
+    @abstractmethod
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        pass
+
+    #
     # Operands
     #
     @property
@@ -74,6 +90,10 @@ class BaseConfiguration(ABC):
         pass
 
     @abstractmethod
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        pass
+
+    @abstractmethod
     def pop_operand(self) -> TValue:
         pass
 
@@ -83,6 +103,50 @@ class BaseConfiguration(ABC):
 
     @abstractmethod
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
+        pass
+
+    #
+    # Pop u32
+    #
+    @abstractmethod
+    def pop_u32(self) -> UInt32:
+        pass
+
+    @abstractmethod
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        pass
+
+    @abstractmethod
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        pass
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    @abstractmethod
+    def pop_f32(self) -> Float32:
+        pass
+
+    @abstractmethod
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        pass
+
+    @abstractmethod
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
         pass
 
     #
@@ -169,6 +233,15 @@ class Configuration(BaseConfiguration):
         return self.frame.active_instructions
 
     #
+    # Results
+    #
+    def push_result(self, value: TValue) -> None:
+        self.result_stack.push(value)
+
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        self.result_stack.extend(values)
+
+    #
     # Operands
     #
     @property
@@ -178,6 +251,9 @@ class Configuration(BaseConfiguration):
     def push_operand(self, value: TValue) -> None:
         self.frame.active_operand_stack.push(value)
 
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        self.frame.active_operand_stack.extend(values)
+
     def pop_operand(self) -> TValue:
         return self.frame.active_operand_stack.pop()
 
@@ -186,6 +262,48 @@ class Configuration(BaseConfiguration):
 
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
         return self.frame.active_operand_stack.pop3()
+
+    #
+    # Pop u32
+    #
+    def pop_u32(self) -> UInt32:
+        return cast(UInt32, self.frame.active_operand_stack.pop())
+
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt32, a), cast(UInt32, b)
+
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt32, a), cast(UInt32, b), cast(UInt32, c)
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    def pop_f32(self) -> Float32:
+        return cast(Float32, self.frame.active_operand_stack.pop())
+
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(Float32, a), cast(Float32, b)
+
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(Float32, a), cast(Float32, b), cast(Float32, c)
 
     #
     # Frames


### PR DESCRIPTION
Builds on #71 

## What was wrong?

While implementing the various logic functions, I found myself needing to consistenly `cast` the operand values that were being popped off the stack.

## How was it fixed?

Formalize this as part of the `Configuration` API to allow the caller to get *typed* values back.

We can have confidence that the values we are popping are indeed of the correct type without runtime checks because expression validation does type checking for each opcode that the values that will be on the stack are indeed of the correct type.

#### Cute Animal Picture

![gizmo-cone](https://user-images.githubusercontent.com/824194/52440071-6c511100-2ada-11e9-9b96-f6c83b585209.jpg)

