### PR TITLE
Extract control opcode logic functionality from `wasm.main` module

### DIFF
--- a/tests/core/execution/test_configuration_object.py
+++ b/tests/core/execution/test_configuration_object.py
@@ -1,0 +1,247 @@
+import pytest
+
+from wasm.datatypes import (
+    Store,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+    Label,
+)
+
+
+@pytest.fixture
+def config():
+    return Configuration(Store())
+
+
+def test_configuration_frame_stack_size(config):
+    assert config.frame_stack_size == 0
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame_stack_size == 1
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame_stack_size == 2
+
+    assert config.pop_frame() is frame_b
+    assert config.pop_frame() is frame_a
+
+    assert config.frame_stack_size == 0
+
+
+def test_configuration_has_active_frame(config):
+    assert config.has_active_frame is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_frame is True
+
+    config.pop_frame()
+
+    assert config.has_active_frame is False
+
+
+def test_configuration_frame_property(config):
+    with pytest.raises(IndexError):
+        config.frame
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame is frame_a
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame is frame_b
+
+    assert config.pop_frame() is frame_b
+
+    assert config.frame is frame_a
+
+
+def test_configuration_has_active_label(config):
+    assert config.has_active_label is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_label is False
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.has_active_label is True
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.has_active_label is False
+
+    # now pop the frame and should have an active label
+    config.pop_frame()
+
+    assert config.has_active_label is True
+
+    config.pop_label()
+
+    assert config.has_active_label is False
+
+
+def test_configuration_active_label_property(config):
+    with pytest.raises(IndexError):
+        config.active_label
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.active_label is label_a
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.active_label is label_b
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.active_label is label_c
+
+
+def test_configuration_instructions_property(config):
+    with pytest.raises(IndexError):
+        config.instructions
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.instructions is frame_a.instructions
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.instructions is label_a.instructions
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.instructions is frame_b.instructions
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.instructions is label_b.instructions
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.instructions is label_c.instructions
+
+
+def test_configuration_push_and_pop_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.operand_stack_size == 0
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.operand_stack_size == 6
+
+    assert config.pop_operand() == 5
+    assert config.operand_stack_size == 5
+    assert config.pop2_operands() == (4, 3)
+    assert config.operand_stack_size == 3
+    assert config.pop3_operands() == (2, 1, 0)
+    assert config.operand_stack_size == 0
+
+
+def test_configuration_push_and_pop_u32_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u32() == 5
+    assert config.pop2_u32() == (4, 3)
+    assert config.pop3_u32() == (2, 1, 0)
+
+
+def test_configuration_push_and_pop_u64_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u64() == 5
+    assert config.pop2_u64() == (4, 3)
+    assert config.pop3_u64() == (2, 1, 0)
+
+
+def test_configuration_get_label_by_idx(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame = Frame(None, [], [], 0)
+    config.push_frame(frame)
+
+    label_3 = Label(0, [], False)
+    config.push_label(label_3)
+    label_2 = Label(0, [], False)
+    config.push_label(label_2)
+    label_1 = Label(0, [], False)
+    config.push_label(label_1)
+    label_0 = Label(0, [], False)
+    config.push_label(label_0)
+
+    assert config.get_by_label_idx(0) is label_0
+    assert config.get_by_label_idx(1) is label_1
+    assert config.get_by_label_idx(2) is label_2
+    assert config.get_by_label_idx(3) is label_3
+
+    with pytest.raises(IndexError):
+        assert config.get_by_label_idx(4)

--- a/wasm/__init__.py
+++ b/wasm/__init__.py
@@ -4,8 +4,3 @@ from .datatypes import (  # noqa: F401
 from .execution import (  # noqa: F401
     Runtime,
 )
-from .main import (  # noqa: F401
-    decode_module,
-    invoke_func,
-    validate_module,
-)

--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -1,6 +1,7 @@
 from typing import (
     NamedTuple,
     Union,
+    cast,
 )
 
 from .addresses import (
@@ -78,13 +79,29 @@ class ExportInstance(NamedTuple):
         return isinstance(self.value, FunctionAddress)
 
     @property
+    def function_address(self) -> FunctionAddress:
+        return cast(FunctionAddress, self.value)
+
+    @property
     def is_global(self):
         return isinstance(self.value, GlobalAddress)
+
+    @property
+    def global_address(self) -> GlobalAddress:
+        return cast(GlobalAddress, self.value)
 
     @property
     def is_memory(self):
         return isinstance(self.value, MemoryAddress)
 
     @property
+    def memory_address(self) -> MemoryAddress:
+        return cast(MemoryAddress, self.value)
+
+    @property
     def is_table(self):
         return isinstance(self.value, TableAddress)
+
+    @property
+    def table_address(self) -> TableAddress:
+        return cast(TableAddress, self.value)

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -1,8 +1,13 @@
 from abc import ABC
 from typing import (
     TYPE_CHECKING,
+    Callable,
     NamedTuple,
     Tuple,
+)
+
+from wasm.typing import (
+    TValue,
 )
 
 from .indices import (
@@ -17,8 +22,8 @@ if TYPE_CHECKING:
     from wasm.instructions import (  # noqa: F401
         BaseInstruction,
     )
-    from wasm.typing import (  # noqa: F401
-        HostFunctionCallable,
+    from wasm.execution import (  # noqa: F401
+        Configuration,
     )
 
 
@@ -49,9 +54,12 @@ class BaseFunctionInstance(ABC):
     type: FunctionType
 
 
+HostFunctionCallable = Callable[['Configuration', Tuple[TValue, ...]], Tuple[TValue, ...]]
+
+
 class HostFunction(NamedTuple):
     type: FunctionType
-    hostcode: 'HostFunctionCallable'
+    hostcode: HostFunctionCallable
 
 
 class StartFunction(NamedTuple):

--- a/wasm/datatypes/store.py
+++ b/wasm/datatypes/store.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Iterable,
     List,
     Tuple,
@@ -12,7 +13,6 @@ from wasm.exceptions import (
     ValidationError,
 )
 from wasm.typing import (
-    HostFunctionCallable,
     TValue,
     UInt32,
 )
@@ -27,6 +27,7 @@ from .function import (
     Function,
     FunctionType,
     HostFunction,
+    HostFunctionCallable,
 )
 from .globals import (
     GlobalInstance,
@@ -50,6 +51,12 @@ from .table import (
     TableInstance,
     TableType,
 )
+
+if TYPE_CHECKING:
+    from wasm.execution import (  # noqa: F401
+        Configuration,
+    )
+
 
 TAddress = Union[FunctionAddress, GlobalAddress, MemoryAddress, TableAddress]
 TExtern = Union[FunctionType, TableType, MemoryType, GlobalType]

--- a/wasm/datatypes/valtype.py
+++ b/wasm/datatypes/valtype.py
@@ -11,9 +11,9 @@ from wasm.typing import (
     Float32,
     Float64,
     TValue,
+    UInt8,
     UInt32,
     UInt64,
-    UInt8,
 )
 
 from .bit_size import (

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -196,11 +196,17 @@ class Configuration(BaseConfiguration):
     def execute(self) -> Tuple[TValue, ...]:
         # TODO: unwrap import once logic functions move out of wasm.main
         from wasm.main import opcode2exec
+        from wasm.logic import OPCODE_TO_LOGIC_FN
 
         while self.has_active_frame:
             instruction = next(self.instructions)
 
-            logic_fn = opcode2exec[instruction.opcode][0]
+            if instruction.opcode in OPCODE_TO_LOGIC_FN:
+                assert instruction.opcode not in opcode2exec
+                logic_fn = OPCODE_TO_LOGIC_FN[instruction.opcode]
+            else:
+                logic_fn = opcode2exec[instruction.opcode][0]
+
             logic_fn(self)
 
         if len(self.result_stack) > 1:

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -3,7 +3,9 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    Iterable,
     Tuple,
+    cast,
 )
 
 from wasm.datatypes import (
@@ -11,7 +13,10 @@ from wasm.datatypes import (
     Store,
 )
 from wasm.typing import (
+    Float32,
     TValue,
+    UInt32,
+    UInt64,
 )
 
 from .instructions import (
@@ -62,6 +67,17 @@ class BaseConfiguration(ABC):
         pass
 
     #
+    # Results
+    #
+    @abstractmethod
+    def push_result(self, value: TValue) -> None:
+        pass
+
+    @abstractmethod
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        pass
+
+    #
     # Operands
     #
     @property
@@ -74,6 +90,10 @@ class BaseConfiguration(ABC):
         pass
 
     @abstractmethod
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        pass
+
+    @abstractmethod
     def pop_operand(self) -> TValue:
         pass
 
@@ -83,6 +103,50 @@ class BaseConfiguration(ABC):
 
     @abstractmethod
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
+        pass
+
+    #
+    # Pop u32
+    #
+    @abstractmethod
+    def pop_u32(self) -> UInt32:
+        pass
+
+    @abstractmethod
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        pass
+
+    @abstractmethod
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        pass
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    @abstractmethod
+    def pop_f32(self) -> Float32:
+        pass
+
+    @abstractmethod
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        pass
+
+    @abstractmethod
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
         pass
 
     #
@@ -169,6 +233,15 @@ class Configuration(BaseConfiguration):
         return self.frame.active_instructions
 
     #
+    # Results
+    #
+    def push_result(self, value: TValue) -> None:
+        self.result_stack.push(value)
+
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        self.result_stack.extend(values)
+
+    #
     # Operands
     #
     @property
@@ -178,6 +251,9 @@ class Configuration(BaseConfiguration):
     def push_operand(self, value: TValue) -> None:
         self.frame.active_operand_stack.push(value)
 
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        self.frame.active_operand_stack.extend(values)
+
     def pop_operand(self) -> TValue:
         return self.frame.active_operand_stack.pop()
 
@@ -186,6 +262,48 @@ class Configuration(BaseConfiguration):
 
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
         return self.frame.active_operand_stack.pop3()
+
+    #
+    # Pop u32
+    #
+    def pop_u32(self) -> UInt32:
+        return cast(UInt32, self.frame.active_operand_stack.pop())
+
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt32, a), cast(UInt32, b)
+
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt32, a), cast(UInt32, b), cast(UInt32, c)
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    def pop_f32(self) -> Float32:
+        return cast(Float32, self.frame.active_operand_stack.pop())
+
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(Float32, a), cast(Float32, b)
+
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(Float32, a), cast(Float32, b), cast(Float32, c)
 
     #
     # Frames

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -1,0 +1,194 @@
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Callable,
+)
+
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from . import control
+
+if TYPE_CHECKING:
+    from wasm.execution import (  # noqa:
+        Configuration,
+    )
+
+
+OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
+    BinaryOpcode.UNREACHABLE: control.unreachable_op,
+    BinaryOpcode.NOP: control.nop_op,
+    BinaryOpcode.BLOCK: control.block_op,
+    BinaryOpcode.LOOP: control.loop_op,
+    BinaryOpcode.IF: control.if_op,
+    BinaryOpcode.ELSE: control.else_op,
+    BinaryOpcode.END: control.end_op,
+    BinaryOpcode.BR: control.br_op,
+    BinaryOpcode.BR_IF: control.br_if_op,
+    BinaryOpcode.BR_TABLE: control.br_table_op,
+    BinaryOpcode.RETURN: control.return_op,
+    BinaryOpcode.CALL: control.call_op,
+    BinaryOpcode.CALL_INDIRECT: control.call_indirect_op,
+    BinaryOpcode.DROP: control.drop_op,
+    BinaryOpcode.SELECT: control.select_op,
+    # BinaryOpcode.GET_LOCAL:
+    # BinaryOpcode.SET_LOCAL:
+    # BinaryOpcode.TEE_LOCAL:
+    # BinaryOpcode.GET_GLOBAL:
+    # BinaryOpcode.SET_GLOBAL:
+    # BinaryOpcode.I32_LOAD:
+    # BinaryOpcode.I64_LOAD:
+    # BinaryOpcode.F32_LOAD:
+    # BinaryOpcode.F64_LOAD:
+    # BinaryOpcode.I32_LOAD8_S:
+    # BinaryOpcode.I32_LOAD8_U:
+    # BinaryOpcode.I32_LOAD16_S:
+    # BinaryOpcode.I32_LOAD16_U:
+    # BinaryOpcode.I64_LOAD8_S:
+    # BinaryOpcode.I64_LOAD8_U:
+    # BinaryOpcode.I64_LOAD16_S:
+    # BinaryOpcode.I64_LOAD16_U:
+    # BinaryOpcode.I64_LOAD32_S:
+    # BinaryOpcode.I64_LOAD32_U:
+    # BinaryOpcode.I32_STORE:
+    # BinaryOpcode.I64_STORE:
+    # BinaryOpcode.F32_STORE:
+    # BinaryOpcode.F64_STORE:
+    # BinaryOpcode.I32_STORE8:
+    # BinaryOpcode.I32_STORE16:
+    # BinaryOpcode.I64_STORE8:
+    # BinaryOpcode.I64_STORE16:
+    # BinaryOpcode.I64_STORE32:
+    # BinaryOpcode.MEMORY_SIZE:
+    # BinaryOpcode.MEMORY_GROW:
+    # BinaryOpcode.I32_CONST:
+    # BinaryOpcode.I64_CONST:
+    # BinaryOpcode.F32_CONST:
+    # BinaryOpcode.F64_CONST:
+    # BinaryOpcode.I32_EQZ:
+    # BinaryOpcode.I32_EQ:
+    # BinaryOpcode.I32_NE:
+    # BinaryOpcode.I32_LT_S:
+    # BinaryOpcode.I32_LT_U:
+    # BinaryOpcode.I32_GT_S:
+    # BinaryOpcode.I32_GT_U:
+    # BinaryOpcode.I32_LE_S:
+    # BinaryOpcode.I32_LE_U:
+    # BinaryOpcode.I32_GE_S:
+    # BinaryOpcode.I32_GE_U:
+    # BinaryOpcode.I64_EQZ:
+    # BinaryOpcode.I64_EQ:
+    # BinaryOpcode.I64_NE:
+    # BinaryOpcode.I64_LT_S:
+    # BinaryOpcode.I64_LT_U:
+    # BinaryOpcode.I64_GT_S:
+    # BinaryOpcode.I64_GT_U:
+    # BinaryOpcode.I64_LE_S:
+    # BinaryOpcode.I64_LE_U:
+    # BinaryOpcode.I64_GE_S:
+    # BinaryOpcode.I64_GE_U:
+    # BinaryOpcode.F32_EQ:
+    # BinaryOpcode.F32_NE:
+    # BinaryOpcode.F32_LT:
+    # BinaryOpcode.F32_GT:
+    # BinaryOpcode.F32_LE:
+    # BinaryOpcode.F32_GE:
+    # BinaryOpcode.F64_EQ:
+    # BinaryOpcode.F64_NE:
+    # BinaryOpcode.F64_LT:
+    # BinaryOpcode.F64_GT:
+    # BinaryOpcode.F64_LE:
+    # BinaryOpcode.F64_GE:
+    # BinaryOpcode.I32_CLZ:
+    # BinaryOpcode.I32_CTZ:
+    # BinaryOpcode.I32_POPCNT:
+    # BinaryOpcode.I32_ADD:
+    # BinaryOpcode.I32_SUB:
+    # BinaryOpcode.I32_MUL:
+    # BinaryOpcode.I32_DIV_S:
+    # BinaryOpcode.I32_DIV_U:
+    # BinaryOpcode.I32_REM_S:
+    # BinaryOpcode.I32_REM_U:
+    # BinaryOpcode.I32_AND:
+    # BinaryOpcode.I32_OR:
+    # BinaryOpcode.I32_XOR:
+    # BinaryOpcode.I32_SHL:
+    # BinaryOpcode.I32_SHR_S:
+    # BinaryOpcode.I32_SHR_U:
+    # BinaryOpcode.I32_ROTL:
+    # BinaryOpcode.I32_ROTR:
+    # BinaryOpcode.I64_CLZ:
+    # BinaryOpcode.I64_CTZ:
+    # BinaryOpcode.I64_POPCNT:
+    # BinaryOpcode.I64_ADD:
+    # BinaryOpcode.I64_SUB:
+    # BinaryOpcode.I64_MUL:
+    # BinaryOpcode.I64_DIV_S:
+    # BinaryOpcode.I64_DIV_U:
+    # BinaryOpcode.I64_REM_S:
+    # BinaryOpcode.I64_REM_U:
+    # BinaryOpcode.I64_AND:
+    # BinaryOpcode.I64_OR:
+    # BinaryOpcode.I64_XOR:
+    # BinaryOpcode.I64_SHL:
+    # BinaryOpcode.I64_SHR_S:
+    # BinaryOpcode.I64_SHR_U:
+    # BinaryOpcode.I64_ROTL:
+    # BinaryOpcode.I64_ROTR:
+    # BinaryOpcode.F32_ABS:
+    # BinaryOpcode.F32_NEG:
+    # BinaryOpcode.F32_CEIL:
+    # BinaryOpcode.F32_FLOOR:
+    # BinaryOpcode.F32_TRUNC:
+    # BinaryOpcode.F32_NEAREST:
+    # BinaryOpcode.F32_SQRT:
+    # BinaryOpcode.F32_ADD:
+    # BinaryOpcode.F32_SUB:
+    # BinaryOpcode.F32_MUL:
+    # BinaryOpcode.F32_DIV:
+    # BinaryOpcode.F32_MIN:
+    # BinaryOpcode.F32_MAX:
+    # BinaryOpcode.F32_COPYSIGN:
+    # BinaryOpcode.F64_ABS:
+    # BinaryOpcode.F64_NEG:
+    # BinaryOpcode.F64_CEIL:
+    # BinaryOpcode.F64_FLOOR:
+    # BinaryOpcode.F64_TRUNC:
+    # BinaryOpcode.F64_NEAREST:
+    # BinaryOpcode.F64_SQRT:
+    # BinaryOpcode.F64_ADD:
+    # BinaryOpcode.F64_SUB:
+    # BinaryOpcode.F64_MUL:
+    # BinaryOpcode.F64_DIV:
+    # BinaryOpcode.F64_MIN:
+    # BinaryOpcode.F64_MAX:
+    # BinaryOpcode.F64_COPYSIGN:
+    # BinaryOpcode.I32_WRAP_I64:
+    # BinaryOpcode.I32_TRUNC_S_F32:
+    # BinaryOpcode.I32_TRUNC_U_F32:
+    # BinaryOpcode.I32_TRUNC_S_F64:
+    # BinaryOpcode.I32_TRUNC_U_F64:
+    # BinaryOpcode.I64_EXTEND_S_I32:
+    # BinaryOpcode.I64_EXTEND_U_I32:
+    # BinaryOpcode.I64_TRUNC_S_F32:
+    # BinaryOpcode.I64_TRUNC_U_F32:
+    # BinaryOpcode.I64_TRUNC_S_F64:
+    # BinaryOpcode.I64_TRUNC_U_F64:
+    # BinaryOpcode.F32_CONVERT_S_I32:
+    # BinaryOpcode.F32_CONVERT_U_I32:
+    # BinaryOpcode.F32_CONVERT_S_I64:
+    # BinaryOpcode.F32_CONVERT_U_I64:
+    # BinaryOpcode.F32_DEMOTE_F64:
+    # BinaryOpcode.F64_CONVERT_S_I32:
+    # BinaryOpcode.F64_CONVERT_U_I32:
+    # BinaryOpcode.F64_CONVERT_S_I64:
+    # BinaryOpcode.F64_CONVERT_U_I64:
+    # BinaryOpcode.F64_PROMOTE_F32:
+    # BinaryOpcode.I32_REINTERPRET_F32:
+    # BinaryOpcode.I64_REINTERPRET_F64:
+    # BinaryOpcode.F32_REINTERPRET_I32:
+    # BinaryOpcode.F64_REINTERPRET_I64:
+    # # special case
+    # InvokeOp:
+}

--- a/wasm/logic/control.py
+++ b/wasm/logic/control.py
@@ -1,0 +1,286 @@
+import logging
+from typing import (
+    Tuple,
+    cast,
+)
+
+from wasm.datatypes import (
+    FunctionAddress,
+    FunctionInstance,
+    HostFunction,
+    LabelIdx,
+)
+from wasm.exceptions import (
+    Exhaustion,
+    Trap,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+    Label,
+)
+from wasm.instructions import (
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Call,
+    CallIndirect,
+    If,
+    Loop,
+)
+from wasm.typing import (
+    TValue,
+)
+
+logger = logging.getLogger('wasm.logic.control')
+
+
+def unreachable_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+    raise Trap("TRAP")
+
+
+def nop_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+
+def block_op(config: Configuration) -> None:
+    block = cast(Block, config.instructions.current)
+
+    logger.debug("%s()", block.opcode.text)
+
+    label = Label(
+        arity=len(block.result_type),
+        instructions=block.instructions,
+        is_loop=False,
+    )
+    config.push_label(label)
+
+
+def loop_op(config: Configuration) -> None:
+    instruction = cast(Loop, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    label = Label(
+        arity=0,
+        instructions=instruction.instructions,
+        is_loop=True,
+    )
+    config.push_label(label)
+
+
+def if_op(config: Configuration) -> None:
+    instruction = cast(If, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    value = config.pop_operand()
+    arity = len(instruction.result_type)
+
+    if value:
+        label = Label(
+            arity=arity,
+            instructions=instruction.instructions,
+            is_loop=False,
+        )
+    else:
+        label = Label(
+            arity=arity,
+            instructions=instruction.else_instructions,
+            is_loop=False,
+        )
+
+    config.push_label(label)
+
+
+def _exit_block(config: Configuration) -> None:
+    label = config.pop_label()
+    config.extend_operands(label.operand_stack)
+
+
+def _return_from_function(config: Configuration) -> None:
+    valn = tuple(config.pop_operand() for _ in range(config.frame.arity))
+    config.pop_frame()
+
+    if config.has_active_frame:
+        config.extend_operands(valn)
+    else:
+        config.extend_results(valn)
+
+
+def else_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    _exit_block(config)
+
+
+def end_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    if config.has_active_label:
+        _exit_block(config)
+    elif config.has_active_frame:
+        _return_from_function(config)
+    else:
+        raise Exception("Invariant?")
+
+
+def _br(config: Configuration, label_idx: LabelIdx) -> None:
+    label = config.get_by_label_idx(label_idx)
+    # take any return values off of the stack before poping labels
+    valn = tuple(config.pop_operand() for _ in range(label.arity))
+
+    if label.is_loop:
+        # For loops we keep the label which represents the loop on the stack
+        # since the continuation of a loop is beginning back at the beginning
+        # of the loop itself.
+        for _ in range(label_idx):
+            config.pop_label()
+        config.instructions.seek(0)
+    else:
+        for _ in range(label_idx + 1):
+            config.pop_label()
+
+    # put return values back on the stack.
+    config.extend_operands(valn)
+
+
+def br_op(config: Configuration) -> None:
+    instruction = cast(Br, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    _br(config, instruction.label_idx)
+
+
+def br_if_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    value = config.pop_operand()
+
+    if value:
+        instruction = cast(BrIf, config.instructions.current)
+        _br(config, instruction.label_idx)
+
+
+def br_table_op(config: Configuration) -> None:
+    instruction = cast(BrTable, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    label_indices = instruction.label_indices
+    default_label_idx = instruction.default_idx
+
+    idx = config.pop_operand()
+
+    if idx < len(label_indices):
+        label_idx = label_indices[int(idx)]
+        _br(config, label_idx)
+    else:
+        _br(config, default_label_idx)
+
+
+def return_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    _return_from_function(config)
+
+
+def _setup_call(config: Configuration, function_address: FunctionAddress) -> None:
+    function = config.store.funcs[function_address]
+    function_args = tuple(reversed([
+        config.pop_operand()
+        for _ in range(len(function.type.params))
+    ]))
+    _setup_function_invocation(config, function_address, function_args)
+
+
+def _setup_function_invocation(config: Configuration,
+                               function_address: FunctionAddress,
+                               function_args: Tuple[TValue, ...]) -> None:
+    if config.frame_stack_size > 1024:
+        # TODO: this is not part of spec, but this is required to pass tests.
+        # Tests pass with limit 10000, maybe more
+        raise Exhaustion("Function length greater than 1024")
+
+    function = config.store.funcs[function_address]
+
+    if len(function_args) != len(function.type.params):
+        raise TypeError(
+            f"Wrong number of arguments. Expected {len(function.type.params)} "
+            f"Got {len(function_args)}"
+        )
+
+    if isinstance(function, FunctionInstance):
+        locals = [valtype.zero_value for valtype in function.code.locals]
+        frame = Frame(
+            module=function.module,
+            locals=list(function_args) + locals,
+            # TODO: do we need this wrapping anymore?
+            instructions=Block.wrap_with_end(function.type.results, function.code.body),
+            arity=len(function.type.results),
+        )
+        config.push_frame(frame)
+    elif isinstance(function, HostFunction):
+        ret = function.hostcode(config, function_args)
+        if len(ret) > 1:
+            raise Exception("Invariant")
+        elif ret:
+            config.push_operand(ret[0])
+    else:
+        raise Exception("Invariant: unreachable code path")
+
+
+def call_op(config: Configuration) -> None:
+    instruction = cast(Call, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    function_address = config.frame.module.func_addrs[instruction.function_idx]
+    _setup_call(config, function_address)
+
+
+def call_indirect_op(config: Configuration) -> None:
+    instruction = cast(CallIndirect, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    table_address = config.frame.module.table_addrs[0]
+    table = config.store.tables[table_address]
+    function_type = config.frame.module.types[instruction.type_idx]
+
+    element_idx = config.pop_u32()
+
+    if len(table.elem) <= element_idx:
+        raise Trap("Element index out of table range: {element_idx} > {len(table.elem)}")
+
+    function_address = table.elem[element_idx]
+
+    if function_address is None:
+        raise Trap("Table element at index {element_idx} is empty")
+
+    function = config.store.funcs[int(function_address)]
+
+    if function.type != function_type:
+        raise Trap("Function type mismatch.  Expected {function_type}.  Got {function.type}")
+
+    _setup_call(config, function_address)
+
+
+def drop_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    config.pop_operand()
+
+
+def select_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    a, b, c = config.pop3_operands()
+
+    if a:
+        config.push_operand(c)
+    else:
+        config.push_operand(b)

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -1,14 +1,10 @@
-import io
 import logging
 import math
 import struct
 from typing import (
     Callable,
     Dict,
-    List,
-    NamedTuple,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -17,49 +13,26 @@ from wasm import (
     constants,
 )
 from wasm.datatypes import (
-    FunctionAddress,
-    FunctionInstance,
     GlobalInstance,
-    HostFunction,
-    LabelIdx,
     MemoryInstance,
-    ModuleInstance,
     Mutability,
-    Store,
     ValType,
 )
 from wasm.exceptions import (
-    Exhaustion,
-    InvalidModule,
-    MalformedModule,
-    ParseError,
     Trap,
     ValidationError,
 )
 from wasm.execution import (
     Configuration,
-    Frame,
-    InstructionSequence,
-    Label,
-    OperandStack,
 )
 from wasm.instructions import (
     BaseInstruction,
     BinOp,
-    Block,
-    Br,
-    BrIf,
-    BrTable,
-    Call,
-    CallIndirect,
     Convert,
     Demote,
-    End,
     Extend,
     GlobalOp,
-    If,
     LocalOp,
-    Loop,
     MemoryOp,
     Promote,
     Reinterpret,
@@ -71,16 +44,8 @@ from wasm.instructions import (
 from wasm.opcodes import (
     BinaryOpcode,
 )
-from wasm.parsers import (
-    parse_module,
-)
 from wasm.typing import (
-    Float32,
-    TValue,
     UInt32,
-)
-from wasm.validation import (
-    validate_module as _validate_module,
 )
 
 logger = logging.getLogger('wasm.spec')
@@ -1264,23 +1229,6 @@ def spec_t2cvtopt1(config: Configuration) -> None:
 # 4.4.2 PARAMETRIC INSTRUCTIONS
 
 
-def spec_drop(config: Configuration) -> None:
-    logger.debug("spec_drop()")
-
-    config.pop_operand()
-
-
-def spec_select(config: Configuration) -> None:
-    logger.debug("spec_select()")
-
-    c, val1, val2 = config.pop3_operands()
-
-    if c:
-        config.push_operand(val2)
-    else:
-        config.push_operand(val1)
-
-
 # 4.4.3 VARIABLE INSTRUCTIONS
 
 
@@ -1453,281 +1401,10 @@ def spec_memorygrow(config: Configuration) -> None:
 """
 
 
-def spec_nop(config):
-    logger.debug("spec_nop()")
-
-
-def spec_unreachable(config):
-    logger.debug("spec_unreachable()")
-
-    raise Trap("trap")
-
-
-def spec_block(config):
-    logger.debug("spec_block()")
-
-    block = cast(Block, config.instructions.current)
-    # 1
-    # 2
-    L = Label(
-        arity=len(block.result_type),
-        instructions=InstructionSequence(block.instructions),
-        is_loop=False,
-    )
-
-    # 3
-    spec_enter_block(config, L)
-
-
-def spec_loop(config: Configuration) -> None:
-    logger.debug("spec_loop()")
-
-    instruction = cast(Loop, config.instructions.current)
-    # 1
-    L = Label(
-        arity=0,
-        instructions=InstructionSequence(instruction.instructions),
-        is_loop=True,
-    )
-    # 2
-    spec_enter_block(config, L)
-
-
-def spec_if(config: Configuration) -> None:
-    logger.debug("spec_if()")
-
-    # 2
-    c = config.pop_operand()
-    # 3
-    instruction = cast(If, config.instructions.current)
-    result_type = instruction.result_type
-
-    n = len(result_type)
-    # 4
-    if c:
-        L = Label(
-            arity=n,
-            instructions=InstructionSequence(instruction.instructions),
-            is_loop=False,
-        )
-    else:
-        L = Label(
-            arity=n,
-            instructions=InstructionSequence(instruction.else_instructions),
-            is_loop=False,
-        )
-
-    spec_enter_block(config, L)
-
-
-def spec_br(config: Configuration, label_idx: LabelIdx = None) -> None:
-    logger.debug('spec_br(%s)', label_idx)
-
-    instruction = cast(Union[Br, BrIf], config.instructions.current)
-
-    if label_idx is None:
-        label_idx = instruction.label_idx
-
-    # 2
-    L = config.get_by_label_idx(label_idx)
-    logger.info('BR: arity: %d', L.arity)
-    # 3
-    # 5
-    # 6
-    valn = tuple(config.pop_operand() for _ in range(L.arity))
-
-    if L.is_loop:
-        for _ in range(label_idx):
-            config.pop_label()
-        assert config.active_label is L
-        config.instructions.seek(0)
-    else:
-        for _ in range(label_idx + 1):
-            config.pop_label()
-    # 7
-    for value in valn:
-        config.push_operand(value)
-    # 8
-
-
-def spec_br_if(config: Configuration) -> None:
-    logger.debug('spec_br_if()')
-
-    instruction = cast(BrIf, config.instructions.current)
-    # 2
-    c = config.pop_operand()
-    # 3
-    if c:
-        spec_br(config, instruction.label_idx)
-    # 4
-
-
-def spec_br_table(config):
-    logger.debug('spec_br_table()')
-
-    instruction = cast(BrTable, config.instructions.current)
-    lstar = instruction.label_indices
-    lN = instruction.default_idx
-    # 2
-    i = config.pop_operand()
-    # 3
-    if i < len(lstar):
-        li = lstar[i]
-        spec_br(config, li)
-    # 4
-    else:
-        spec_br(config, lN)
-
-
-def spec_return(config: Configuration) -> None:
-    logger.debug('spec_return()')
-
-    # 1
-    # 2
-    n = config.frame.arity
-    # 4
-    # 6
-    valn = list(reversed([
-        config.pop_operand()
-        for _ in range(n)
-    ]))
-
-    # 8
-    config.pop_frame()
-    # 9
-    for value in valn:
-        config.push_operand(value)
-
-
-def spec_call(config: Configuration) -> None:
-    logger.debug('spec_call()')
-
-    instruction = cast(Call, config.instructions.current)
-    # 1
-    # 3
-    addr = config.frame.module.func_addrs[instruction.function_idx]
-    # 4
-    spec_invoke_function_address(config, addr)
-
-
-def spec_call_indirect(config: Configuration) -> None:
-    logger.debug('spec_call_indirect()')
-
-    S = config.store
-    # 1
-    # 3
-    ta = config.frame.module.table_addrs[0]
-    # 5
-    tab = S.tables[ta]
-    # 7
-    instruction = cast(CallIndirect, config.instructions.current)
-    ftexpect = config.frame.module.types[instruction.type_idx]
-    # 9
-    i = int(config.pop_operand())
-    # 10
-    if len(tab.elem) <= i:
-        raise Trap("trap")
-    # 11
-    if tab.elem[i] is None:
-        raise Trap("trap")
-    # 12
-    addr = tab.elem[i]
-    if addr is None:
-        raise Exception("Invalid: TODO")
-    # 14
-    f = S.funcs[addr]
-    # 15
-    ftactual = f.type
-    # 16
-    if ftexpect != ftactual:
-        raise Trap("trap")
-    # 17
-    spec_invoke_function_address(config, addr)
-
-
 # 4.4.6 BLOCKS
 
 
-def spec_enter_block(config: Configuration, L: Label) -> None:
-    logger.debug('spec_enter_block(%s)', L)
-
-    config.push_label(L)
-
-
-def spec_exit_block(config):
-    logger.debug('spec_exit_block(%s)', config.active_label)
-
-    L = config.pop_label()
-    for val in L.operand_stack:
-        config.push_operand(val)
-
-
 # 4.4.7 FUNCTION CALLS
-
-def spec_invoke_function_address(config: Configuration,
-                                 func_addr: FunctionAddress = None,
-                                 ) -> None:
-    logger.debug('spec_invoke_function_address(%s)', func_addr)
-
-    S = config.store
-    if config.frame_stack_size > 1024:
-        # TODO: this is not part of spec, but this is required to pass tests.
-        # Tests pass with limit 10000, maybe more
-        raise Exhaustion("Function length greater than 1024")
-
-    if func_addr is None:
-        if isinstance(config.instructions.current, InvokeInstruction):
-            func_addr = config.instructions.current.func_addr
-        else:
-            raise TypeError(
-                "No function address was provided and cannot get address from "
-                "instruction."
-            )
-
-    # 2
-    f = S.funcs[func_addr]
-    # 3
-    t1n, t2m = f.type
-    if isinstance(f, FunctionInstance):
-        # 5
-        tstar = f.code.locals
-        # 6
-        instrstarend = f.code.body
-        # 8
-        valn = list(reversed([
-            config.pop_operand()
-            for _ in range(len(t1n))
-        ]))
-        # 9
-        val0star: List[TValue] = []
-        for valtype in tstar:
-            if valtype.is_integer_type:
-                val0star.append(UInt32(0))
-            elif valtype.is_float_type:
-                val0star.append(Float32(0.0))
-            else:
-                raise Exception(f"Invariant: unkown type '{valtype}'")
-        # 10 & 11
-        blockinstrstarendend = InstructionSequence(
-            Block.wrap_with_end(t2m, instrstarend)
-        )
-        F = Frame(
-            module=f.module,
-            locals=valn + val0star,
-            instructions=blockinstrstarendend,
-            arity=len(t2m),
-        )
-        config.push_frame(F)
-    elif isinstance(f, HostFunction):
-        valn = [config.pop_operand() for _ in range(len(t1n))]
-        _, ret = f.hostcode(S, valn)
-        if len(ret) > 1:
-            raise Exception("Invariant")
-        elif ret:
-            config.push_operand(ret[0])
-    else:
-        raise Exception("Invariant: unreachable code path")
-
 
 def spec_return_from_func(config: Configuration) -> None:
     logger.debug('spec_return_from_func()')
@@ -1746,51 +1423,28 @@ def spec_return_from_func(config: Configuration) -> None:
             config.result_stack.push(arg)
 
 
-def spec_end(config: Configuration) -> None:
-    logger.debug('spec_end()')
-
-    if config.has_active_label:
-        spec_exit_block(config)
-    elif config.has_active_frame:
-        spec_return_from_func(config)
-    else:
-        raise Exception("Invariant?")
-
-
 # 4.4.8 EXPRESSIONS
-
-
-class InvokeOp:
-    text = 'invoke'
-
-
-class InvokeInstruction(NamedTuple):
-    func_addr: FunctionAddress
-
-    @property
-    def opcode(self) -> Type[InvokeOp]:
-        return InvokeOp
 
 
 # Map each opcode to the function(s) to invoke when it is encountered. For
 # opcodes with two functions, the second function is called by the first
 # function.
-opcode2exec: Dict[Union[Type[InvokeOp], BinaryOpcode], Tuple[Callable, ...]] = {
-    BinaryOpcode.UNREACHABLE: (spec_unreachable,),
-    BinaryOpcode.NOP: (spec_nop,),
-    BinaryOpcode.BLOCK: (spec_block,),  # blocktype in* end
-    BinaryOpcode.LOOP: (spec_loop,),  # blocktype in* end
-    BinaryOpcode.IF: (spec_if,),  # blocktype in1* else? in2* end
-    BinaryOpcode.ELSE: (spec_end,),  # in2*
-    BinaryOpcode.END: (spec_end,),
-    BinaryOpcode.BR: (spec_br,),  # labelidx
-    BinaryOpcode.BR_IF: (spec_br_if,),  # labelidx
-    BinaryOpcode.BR_TABLE: (spec_br_table,),  # labelidx* labelidx
-    BinaryOpcode.RETURN: (spec_return,),
-    BinaryOpcode.CALL: (spec_call,),  # funcidx
-    BinaryOpcode.CALL_INDIRECT: (spec_call_indirect,),  # typeidx 0x00
-    BinaryOpcode.DROP: (spec_drop,),
-    BinaryOpcode.SELECT: (spec_select,),
+opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
+    # BinaryOpcode.UNREACHABLE: (spec_unreachable,),
+    # BinaryOpcode.NOP: (spec_nop,),
+    # BinaryOpcode.BLOCK: (spec_block,),  # blocktype in* end
+    # BinaryOpcode.LOOP: (spec_loop,),  # blocktype in* end
+    # BinaryOpcode.IF: (spec_if,),  # blocktype in1* else? in2* end
+    # BinaryOpcode.ELSE: (spec_end,),  # in2*
+    # BinaryOpcode.END: (spec_end,),
+    # BinaryOpcode.BR: (spec_br,),  # labelidx
+    # BinaryOpcode.BR_IF: (spec_br_if,),  # labelidx
+    # BinaryOpcode.BR_TABLE: (spec_br_table,),  # labelidx* labelidx
+    # BinaryOpcode.RETURN: (spec_return,),
+    # BinaryOpcode.CALL: (spec_call,),  # funcidx
+    # BinaryOpcode.CALL_INDIRECT: (spec_call_indirect,),  # typeidx 0x00
+    # BinaryOpcode.DROP: (spec_drop,),
+    # BinaryOpcode.SELECT: (spec_select,),
     BinaryOpcode.GET_LOCAL: (spec_get_local,),  # localidx
     BinaryOpcode.SET_LOCAL: (spec_set_local,),  # localidx
     BinaryOpcode.TEE_LOCAL: (spec_tee_local,),  # localidx
@@ -1948,8 +1602,6 @@ opcode2exec: Dict[Union[Type[InvokeOp], BinaryOpcode], Tuple[Callable, ...]] = {
     BinaryOpcode.I64_REINTERPRET_F64: (spec_t2cvtopt1, spec_reinterprett1t2),
     BinaryOpcode.F32_REINTERPRET_I32: (spec_t2cvtopt1, spec_reinterprett1t2),
     BinaryOpcode.F64_REINTERPRET_I64: (spec_t2cvtopt1, spec_reinterprett1t2),
-    # special case
-    InvokeOp: (spec_invoke_function_address,),
 }
 
 
@@ -1992,59 +1644,6 @@ def spec_growmem(meminst: MemoryInstance, n: UInt32) -> None:
 # 4.5.5 INVOCATION
 
 # valn looks like [["i32.const",3],["i32.const",199], ...]
-def spec_invoke(S: Store,
-                funcaddr: FunctionAddress,
-                valn: Tuple[Tuple[ValType, TValue], ...] = None,
-                ) -> Tuple[TValue, ...]:
-    logger.debug('spec_invoke()')
-
-    # 1
-    if len(S.funcs) < funcaddr or funcaddr < 0:
-        raise Exception("bad address")
-    # 2
-    funcinst = S.funcs[funcaddr]
-    # 5
-    t1n, t2m = funcinst.type
-    # 4
-    if valn is None:
-        valn = tuple()
-
-    if len(valn) != len(t1n):
-        raise Exception("wrong number of arguments")
-    # 5
-    for ti, (valt, val) in zip(t1n, valn):
-        if ti is not valt:
-            raise Exception("argument type mismatch")
-
-    # 6
-    # 7
-    if isinstance(funcinst, FunctionInstance):
-        F = Frame(
-            module=ModuleInstance((), (), (), (), (), ()),
-            locals=[],
-            instructions=InstructionSequence(cast(
-                Tuple[BaseInstruction, ...],
-                (InvokeInstruction(funcaddr), End()),
-            )),
-            arity=len(t2m),
-        )
-        config = Configuration(store=S)
-        config.push_frame(F)
-        for _, arg in valn:
-            config.push_operand(arg)
-
-        valresm = config.execute()
-        assert valresm is not None
-        return valresm
-    elif isinstance(funcinst, HostFunction):
-        operand_stack = OperandStack()
-        for _, arg in valn:
-            operand_stack.push(arg)
-        S, valresm = funcinst.hostcode(S, operand_stack)
-        assert valresm is not None
-        return valresm
-    else:
-        raise Exception(f"Invariant: unknown function type: {type(funcinst)}")
 
 
 ###################
@@ -2182,30 +1781,10 @@ def spec_invoke(S: Store,
 # 7.1.2 MODULES
 
 
-def decode_module(bytestar):
-    stream = io.BytesIO(bytestar)
-    try:
-        return parse_module(stream)
-    except ParseError as err:
-        raise MalformedModule from err
-
-
-def validate_module(module):
-    try:
-        _validate_module(module)
-    except ValidationError as err:
-        raise InvalidModule from err
-
-
 # 7.1.3 EXPORTS
 
 
 # 7.1.4 FUNCTIONS
-
-
-def invoke_func(store, funcaddr, valstar):
-    ret = spec_invoke(store, funcaddr, valstar)
-    return store, ret
 
 
 # 7.1.4 TABLES

--- a/wasm/tools/fixtures/datatypes.py
+++ b/wasm/tools/fixtures/datatypes.py
@@ -2,15 +2,18 @@ from pathlib import (
     Path,
 )
 from typing import (
-    TYPE_CHECKING,
     NamedTuple,
     Optional,
     Tuple,
     Union,
 )
 
-if TYPE_CHECKING:
-    from wasm.datatypes import ValType  # noqa: F401
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.typing import (
+    TValue,
+)
 
 
 class ModuleCommand(NamedTuple):
@@ -20,13 +23,13 @@ class ModuleCommand(NamedTuple):
 
 
 class Argument(NamedTuple):
-    type: 'ValType'
-    value: Union[int, float]
+    valtype: ValType
+    value: TValue
 
 
 class Expected(NamedTuple):
-    type: 'ValType'
-    value: Union[None, int, float]
+    valtype: ValType
+    value: Union[None, TValue]
 
 
 class Action(NamedTuple):

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -1,4 +1,7 @@
 import logging
+from typing import (
+    Tuple,
+)
 
 from wasm.datatypes import (
     ExportInstance,
@@ -16,9 +19,13 @@ from wasm.datatypes import (
     TableType,
     ValType,
 )
+from wasm.execution import (
+    Configuration,
+)
 from wasm.typing import (
     Float32,
     Float64,
+    TValue,
     UInt32,
 )
 
@@ -26,33 +33,35 @@ from wasm.typing import (
 def instantiate_spectest_module(store: Store) -> ModuleInstance:
     logger = logging.getLogger("wasm.tools.fixtures.modules.spectest")
 
-    def spectest__print_i32(store, arg):
-        logger.debug('print_i32: %s', arg)
-        return store, []
+    def spectest__print_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i32: %s', args)
+        return tuple()
 
-    def spectest__print_i64(store, arg):
-        logger.debug('print_i64: %s', arg)
-        return store, []
+    def spectest__print_i64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i64: %s', args)
+        return tuple()
 
-    def spectest__print_f32(store, arg):
-        logger.debug('print_f32: %s', arg)
-        return store, []
+    def spectest__print_f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f32: %s', args)
+        return tuple()
 
-    def spectest__print_f64(store, arg):
-        logger.debug('print_f64: %s', arg)
-        return store, []
+    def spectest__print_f64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f64: %s', args)
+        return tuple()
 
-    def spectest__print_i32_f32(store, arg):
-        logger.debug('print_i32_f32: %s', arg)
-        return store, []
+    def spectest__print_i32_f32(config: Configuration,
+                                args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i32_f32: %s', args)
+        return tuple()
 
-    def spectest__print_f64_f64(store, arg):
-        logger.debug('print_f64_f64: %s', arg)
-        return store, []
+    def spectest__print_f64_f64(config: Configuration,
+                                args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f64_f64: %s', args)
+        return tuple()
 
-    def spectest__print(store, arg):
-        logger.debug('print: %s', arg)
-        return store, []
+    def spectest__print(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print: %s', args)
+        return tuple()
 
     store.allocate_host_function(FunctionType((ValType.i32,), ()), spectest__print_i32)
     store.allocate_host_function(FunctionType((ValType.i64,), ()), spectest__print_i64)
@@ -112,40 +121,46 @@ def instantiate_spectest_module(store: Store) -> ModuleInstance:
 
 
 # this module called "wast" is used by import.wast to test for assert_unlinkable
-def instantiate_test_module(store):
-    def test__func(store, arg):
-        pass
+def instantiate_test_module(store: Store) -> ModuleInstance:
+    def test__func(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i32(store, arg):
-        pass
+    def test__func_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_f32(store, arg):
-        pass
+    def test__func_f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func__i32(store, arg):
-        pass
+    def test__func__i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func__f32(store, arg):
-        pass
+    def test__func__f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i32_i32(store, arg):
-        pass
+    def test__func_i32_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i64_i64(store, arg):
-        pass
+    def test__func_i64_i64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
     store.allocate_host_function(FunctionType((), ()), test__func)
     store.allocate_host_function(FunctionType((ValType.i32,), ()), test__func_i32)
     store.allocate_host_function(FunctionType((ValType.f32,), ()), test__func_f32)
     store.allocate_host_function(FunctionType((), (ValType.i32,)), test__func__i32)
     store.allocate_host_function(FunctionType((), (ValType.f32,)), test__func__f32)
-    store.allocate_host_function(FunctionType((ValType.i32,), (ValType.i32,)), test__func_i32_i32)
-    store.allocate_host_function(FunctionType((ValType.i64,), (ValType.i64,)), test__func_i64_i64)
+    store.allocate_host_function(
+        FunctionType((ValType.i32,), (ValType.i32,)),
+        test__func_i32_i32,
+    )
+    store.allocate_host_function(
+        FunctionType((ValType.i64,), (ValType.i64,)),
+        test__func_i64_i64,
+    )
 
-    store.allocate_memory(MemoryType(1, None))
+    store.allocate_memory(MemoryType(UInt32(1), None))
     store.allocate_global(GlobalType(Mutability.const, ValType.i32), UInt32(666))
     store.allocate_global(GlobalType(Mutability.const, ValType.f32), Float32(0.0))
-    store.allocate_table(TableType(Limits(10, None), FunctionAddress))
+    store.allocate_table(TableType(Limits(UInt32(10), None), FunctionAddress))
     moduleinst = ModuleInstance(
         types=(
             FunctionType((), ()),

--- a/wasm/tools/fixtures/normalizers.py
+++ b/wasm/tools/fixtures/normalizers.py
@@ -18,6 +18,11 @@ from mypy_extensions import (
 from wasm.datatypes import (
     ValType,
 )
+from wasm.typing import (
+    TValue,
+    UInt32,
+    UInt64,
+)
 
 from .datatypes import (
     Action,
@@ -73,21 +78,21 @@ def normalize_argument(raw_argument: RawCommand) -> Argument:
         raise Exception(f"Unexpected keys: {extra_keys}")
 
     raw_type = raw_argument['type']
-    type_ = ValType.from_str(raw_type)
+    valtype = ValType.from_str(raw_type)
 
-    value: Union[int, float]
+    value: TValue
 
-    if type_.is_integer_type:
-        value = int(raw_argument['value'])
-    elif type_ is ValType.f32:
-        value = int_to_float(32, int(raw_argument['value']))
-    elif type_ is ValType.f64:
-        value = int_to_float(64, int(raw_argument['value']))
+    if valtype is ValType.i32:
+        value = UInt32(int(raw_argument['value']))
+    elif valtype is ValType.i64:
+        value = UInt64(int(raw_argument['value']))
+    elif valtype.is_float_type:
+        value = int_to_float(valtype.bit_size.value, int(raw_argument['value']))
     else:
-        raise Exception(f"Unhandled type: {type_} | value: {raw_argument['value']}")
+        raise Exception(f"Unhandled type: {valtype} | value: {raw_argument['value']}")
 
     return Argument(
-        type=type_,
+        valtype=valtype,
         value=value,
     )
 
@@ -136,24 +141,24 @@ def normalize_expected(raw_expected: RawCommand) -> Expected:
         raise Exception(f"Unexpected keys: {extra_keys}")
 
     raw_type = raw_expected['type']
-    type_ = ValType.from_str(raw_type)
+    valtype = ValType.from_str(raw_type)
 
     value: Optional[Union[int, float]]
 
     if 'value' in raw_expected:
-        if type_.is_integer_type:
-            value = int(raw_expected['value'])
-        elif type_ is ValType.f32:
-            value = int_to_float(32, int(raw_expected['value']))
-        elif type_ is ValType.f64:
-            value = int_to_float(64, int(raw_expected['value']))
+        if valtype is ValType.i32:
+            value = UInt32(int(raw_expected['value']))
+        elif valtype is ValType.i64:
+            value = UInt64(int(raw_expected['value']))
+        elif valtype.is_float_type:
+            value = int_to_float(valtype.bit_size.value, int(raw_expected['value']))
         else:
-            raise Exception(f"Unhandled type: {type_} | value: {raw_expected['value']}")
+            raise Exception(f"Unhandled type: {valtype} | value: {raw_expected['value']}")
     else:
         value = None
 
     return Expected(
-        type=type_,
+        valtype=valtype,
         value=value,
     )
 

--- a/wasm/tools/fixtures/numeric.py
+++ b/wasm/tools/fixtures/numeric.py
@@ -1,18 +1,26 @@
 import struct
+from typing import (
+    Union,
+)
+
+from wasm.typing import (
+    Float32,
+    Float64,
+)
 
 
-def int_to_float(num_bits: int, value: int) -> float:
+def int_to_float(num_bits: int, value: int) -> Union[Float32, Float64]:
     """
     Convert an integer to the equivalent floating point value.
     """
+    value_as_bytes = value.to_bytes(num_bits // 8, 'big')
+
     if num_bits == 32:
-        unpack_fmt = '>f'
+        return Float32(struct.unpack('>f', value_as_bytes)[0])
     elif num_bits == 64:
-        unpack_fmt = '>d'
+        return Float32(struct.unpack('>d', value_as_bytes)[0])
     else:
         raise Exception(f"Unhandled bit size: {num_bits}")
-
-    return struct.unpack(unpack_fmt, value.to_bytes(num_bits // 8, 'big'))[0]
 
 
 def get_bit_size(_type: str) -> int:

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -1,13 +1,7 @@
 from typing import (
-    Any,
-    Callable,
     NewType,
-    Tuple,
     Union,
 )
-
-HostFunctionCallable = Callable[[Any, Any], Tuple[Any, Any]]
-
 
 UInt8 = NewType('UInt8', int)
 UInt32 = NewType('UInt32', int)


### PR DESCRIPTION
Builds on #72 and #70 

## What was wrong?

The existing opcode implementations are implemented using the exact functional composition that the spec defines.  This often involves calling through multiple functions to do even simple tasks and results in hard to read code.  

For example, the bitwise rotation is done by 

- converting the number to it's string-formated binary representation 
- slicing the string and re-joined to rotate the bits
- converting the string-formatted binary representation back into an integer.

In addition, the numeric operations are implemented using a form of indirection, where each *unary* opcode's execution involves execution of a common entry point function which pops the values off the stack, then calling out to a second function for the actual opcode logic.  Again, this indirection makes things difficult to read/follow and adds a lot of call overhead.

These functions all live in the `wasm.main` legacy module and in total account for around 1-2k lines of code.

## How was it fixed?

This PR pulls out the *control* opcode logic functions.  As part of this, the invocation APIs and other top level APIs have been moved to the `Runtime` object.

#### Cute Animal Picture

![tumblr_m8nghwgmjr1qbwakso1_500](https://user-images.githubusercontent.com/824194/52447157-349f9480-2aed-11e9-86c8-e61b041f4caa.jpg)

