### PR TITLE
Convert parser typing to use typing.IO

### DIFF
--- a/wasm/parsers/blocks.py
+++ b/wasm/parsers/blocks.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Tuple,
 )
 
@@ -15,7 +15,7 @@ from .byte import (
 )
 
 
-def parse_blocktype(stream: io.BytesIO) -> Tuple[ValType, ...]:
+def parse_blocktype(stream: IO[bytes]) -> Tuple[ValType, ...]:
     byte = parse_single_byte(stream)
     if byte == 0x40:
         return tuple()

--- a/wasm/parsers/byte.py
+++ b/wasm/parsers/byte.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.exceptions import (
     ParseError,
@@ -12,7 +12,7 @@ from .integers import (
 )
 
 
-def parse_single_byte(stream: io.BytesIO) -> UInt8:
+def parse_single_byte(stream: IO[bytes]) -> UInt8:
     byte = stream.read(1)
 
     if byte:
@@ -21,7 +21,7 @@ def parse_single_byte(stream: io.BytesIO) -> UInt8:
         raise ParseError("Unexpected end of stream")
 
 
-def parse_bytes(stream: io.BytesIO) -> bytes:
+def parse_bytes(stream: IO[bytes]) -> bytes:
     size = parse_u32(stream)
     data = stream.read(size)
 

--- a/wasm/parsers/code.py
+++ b/wasm/parsers/code.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm import (
     constants,
@@ -25,13 +25,13 @@ from .vector import (
 )
 
 
-def parse_locals(stream: io.BytesIO) -> LocalsMeta:
+def parse_locals(stream: IO[bytes]) -> LocalsMeta:
     num = parse_u32(stream)
     valtype = parse_valtype(stream)
     return LocalsMeta(num, valtype)
 
 
-def parse_code(stream: io.BytesIO) -> Code:
+def parse_code(stream: IO[bytes]) -> Code:
     size = parse_u32(stream)
     start_pos = stream.tell()
     expected_end_pos = start_pos + size

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Iterable,
     Tuple,
     cast,
@@ -46,7 +46,7 @@ from .vector import (
 
 
 def parse_control_instruction(opcode: BinaryOpcode,
-                              stream: io.BytesIO) -> Instruction:
+                              stream: IO[bytes]) -> Instruction:
     if opcode is BinaryOpcode.UNREACHABLE:
         return Unreachable()
     elif opcode is BinaryOpcode.NOP:
@@ -77,18 +77,18 @@ def parse_control_instruction(opcode: BinaryOpcode,
         raise Exception(f"Unhandled: {opcode}")
 
 
-def parse_block_instruction(stream: io.BytesIO) -> Block:
+def parse_block_instruction(stream: IO[bytes]) -> Block:
     result_type = parse_blocktype(stream)
     instructions = parse_inner_block_instructions(stream)
 
     return Block(result_type, instructions)
 
 
-def parse_inner_block_instructions(stream: io.BytesIO) -> Tuple[BaseInstruction, ...]:
+def parse_inner_block_instructions(stream: IO[bytes]) -> Tuple[BaseInstruction, ...]:
     return tuple(_parse_inner_block_instructions(stream))
 
 
-def _parse_inner_block_instructions(stream: io.BytesIO) -> Iterable[BaseInstruction]:
+def _parse_inner_block_instructions(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     # recursive parsing
     from wasm.parsers.instructions import parse_instruction  # noqa: F401
 
@@ -99,14 +99,14 @@ def _parse_inner_block_instructions(stream: io.BytesIO) -> Iterable[BaseInstruct
             break
 
 
-def parse_loop_instruction(stream: io.BytesIO) -> Loop:
+def parse_loop_instruction(stream: IO[bytes]) -> Loop:
     result_type = parse_blocktype(stream)
     instructions = parse_inner_block_instructions(stream)
 
     return Loop(result_type, instructions)
 
 
-def parse_if_instruction(stream: io.BytesIO) -> If:
+def parse_if_instruction(stream: IO[bytes]) -> If:
     result_type = parse_blocktype(stream)
 
     all_instructions = parse_inner_block_instructions(stream)
@@ -131,29 +131,29 @@ def parse_if_instruction(stream: io.BytesIO) -> If:
     )
 
 
-def parse_br_instruction(stream: io.BytesIO) -> Br:
+def parse_br_instruction(stream: IO[bytes]) -> Br:
     label = parse_label_idx(stream)
     return Br(label)
 
 
-def parse_br_if_instruction(stream: io.BytesIO) -> BrIf:
+def parse_br_if_instruction(stream: IO[bytes]) -> BrIf:
     label = parse_label_idx(stream)
     return BrIf(label)
 
 
-def parse_br_table_instruction(stream: io.BytesIO) -> BrTable:
+def parse_br_table_instruction(stream: IO[bytes]) -> BrTable:
     labels = parse_vector(parse_label_idx, stream)
     default_label = parse_label_idx(stream)
 
     return BrTable(labels, default_label)
 
 
-def parse_call_instruction(stream: io.BytesIO) -> Call:
+def parse_call_instruction(stream: IO[bytes]) -> Call:
     function_idx = parse_function_idx(stream)
     return Call(function_idx)
 
 
-def parse_call_indirect_instruction(stream: io.BytesIO) -> CallIndirect:
+def parse_call_indirect_instruction(stream: IO[bytes]) -> CallIndirect:
     type_idx = parse_type_idx(stream)
     parse_null_byte(stream)
 

--- a/wasm/parsers/data_segment.py
+++ b/wasm/parsers/data_segment.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     DataSegment,
@@ -15,7 +15,7 @@ from .indices import (
 )
 
 
-def parse_data_segment(stream: io.BytesIO) -> DataSegment:
+def parse_data_segment(stream: IO[bytes]) -> DataSegment:
     memory_idx = parse_memory_idx(stream)
     offset = parse_expression(stream)
     init = parse_bytes(stream)

--- a/wasm/parsers/element_segment.py
+++ b/wasm/parsers/element_segment.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     ElementSegment,
@@ -16,7 +16,7 @@ from .vector import (
 )
 
 
-def parse_element_segment(stream: io.BytesIO) -> ElementSegment:
+def parse_element_segment(stream: IO[bytes]) -> ElementSegment:
     table_idx = parse_table_idx(stream)
     offset = parse_expression(stream)
     init = parse_vector(parse_function_idx, stream)

--- a/wasm/parsers/exports.py
+++ b/wasm/parsers/exports.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Union,
 )
 
@@ -30,7 +30,7 @@ from .text import (
 TExportDesc = Union[FunctionIdx, GlobalIdx, MemoryIdx, TableIdx]
 
 
-def parse_export_descriptor(stream: io.BytesIO) -> TExportDesc:
+def parse_export_descriptor(stream: IO[bytes]) -> TExportDesc:
     flag = parse_single_byte(stream)
 
     if flag == 0x00:
@@ -47,7 +47,7 @@ def parse_export_descriptor(stream: io.BytesIO) -> TExportDesc:
         )
 
 
-def parse_export(stream: io.BytesIO) -> Export:
+def parse_export(stream: IO[bytes]) -> Export:
     name = parse_text(stream)
     descriptor = parse_export_descriptor(stream)
     return Export(name, descriptor)

--- a/wasm/parsers/expressions.py
+++ b/wasm/parsers/expressions.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Iterable,
     Tuple,
     cast,
@@ -17,11 +17,11 @@ from .instructions import (
 )
 
 
-def parse_expression(stream: io.BytesIO) -> Tuple[BaseInstruction, ...]:
+def parse_expression(stream: IO[bytes]) -> Tuple[BaseInstruction, ...]:
     return tuple(_parse_expression(stream))
 
 
-def _parse_expression(stream: io.BytesIO) -> Iterable[BaseInstruction]:
+def _parse_expression(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     while True:
         instruction = cast(BaseInstruction, parse_instruction(stream))
 

--- a/wasm/parsers/floats.py
+++ b/wasm/parsers/floats.py
@@ -1,6 +1,6 @@
-import io
 import struct
 from typing import (
+    IO,
     cast,
 )
 
@@ -10,7 +10,7 @@ from wasm.typing import (
 )
 
 
-def parse_f32(stream: io.BytesIO) -> Float32:
+def parse_f32(stream: IO[bytes]) -> Float32:
     raw_buffer = stream.read(4)
     buffer = bytes(reversed(raw_buffer))
     if len(buffer) < 4:
@@ -20,7 +20,7 @@ def parse_f32(stream: io.BytesIO) -> Float32:
     return cast(Float32, value)
 
 
-def parse_f64(stream: io.BytesIO) -> Float64:
+def parse_f64(stream: IO[bytes]) -> Float64:
     raw_buffer = stream.read(8)
     buffer = bytes(reversed(raw_buffer))
     if len(buffer) < 8:

--- a/wasm/parsers/functions.py
+++ b/wasm/parsers/functions.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     FunctionType,
@@ -22,7 +22,7 @@ from .vector import (
 )
 
 
-def parse_function_type(stream: io.BytesIO) -> FunctionType:
+def parse_function_type(stream: IO[bytes]) -> FunctionType:
     flag = parse_single_byte(stream)
 
     if flag != 0x60:
@@ -36,6 +36,6 @@ def parse_function_type(stream: io.BytesIO) -> FunctionType:
     return FunctionType(params, results)
 
 
-def parse_start_function(stream: io.BytesIO) -> StartFunction:
+def parse_start_function(stream: IO[bytes]) -> StartFunction:
     function_idx = parse_function_idx(stream)
     return StartFunction(function_idx)

--- a/wasm/parsers/globals.py
+++ b/wasm/parsers/globals.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     Global,
@@ -16,13 +16,13 @@ from .valtype import (
 )
 
 
-def parse_global_type(stream: io.BytesIO) -> GlobalType:
+def parse_global_type(stream: IO[bytes]) -> GlobalType:
     valtype = parse_valtype(stream)
     mut = parse_mut(stream)
     return GlobalType(mut, valtype)
 
 
-def parse_global(stream: io.BytesIO) -> Global:
+def parse_global(stream: IO[bytes]) -> Global:
     global_type = parse_global_type(stream)
     init = parse_expression(stream)
     return Global(global_type, init)

--- a/wasm/parsers/imports.py
+++ b/wasm/parsers/imports.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Union,
 )
 
@@ -36,7 +36,7 @@ from .text import (
 TImportDesc = Union[TypeIdx, GlobalType, MemoryType, TableType]
 
 
-def parse_import_descriptor(stream: io.BytesIO) -> TImportDesc:
+def parse_import_descriptor(stream: IO[bytes]) -> TImportDesc:
     type_flag = parse_single_byte(stream)
 
     if type_flag == 0x00:
@@ -53,7 +53,7 @@ def parse_import_descriptor(stream: io.BytesIO) -> TImportDesc:
         )
 
 
-def parse_import(stream: io.BytesIO) -> Import:
+def parse_import(stream: IO[bytes]) -> Import:
     module = parse_text(stream)
     name = parse_text(stream)
     descriptor = parse_import_descriptor(stream)

--- a/wasm/parsers/indices.py
+++ b/wasm/parsers/indices.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     FunctionIdx,
@@ -15,36 +15,36 @@ from .integers import (
 )
 
 
-def parse_function_idx(stream: io.BytesIO) -> FunctionIdx:
+def parse_function_idx(stream: IO[bytes]) -> FunctionIdx:
     raw_idx = parse_u32(stream)
     return FunctionIdx(raw_idx)
 
 
-def parse_global_idx(stream: io.BytesIO) -> GlobalIdx:
+def parse_global_idx(stream: IO[bytes]) -> GlobalIdx:
     raw_idx = parse_u32(stream)
     return GlobalIdx(raw_idx)
 
 
-def parse_label_idx(stream: io.BytesIO) -> LabelIdx:
+def parse_label_idx(stream: IO[bytes]) -> LabelIdx:
     raw_idx = parse_u32(stream)
     return LabelIdx(raw_idx)
 
 
-def parse_local_idx(stream: io.BytesIO) -> LocalIdx:
+def parse_local_idx(stream: IO[bytes]) -> LocalIdx:
     raw_idx = parse_u32(stream)
     return LocalIdx(raw_idx)
 
 
-def parse_memory_idx(stream: io.BytesIO) -> MemoryIdx:
+def parse_memory_idx(stream: IO[bytes]) -> MemoryIdx:
     raw_idx = parse_u32(stream)
     return MemoryIdx(raw_idx)
 
 
-def parse_table_idx(stream: io.BytesIO) -> TableIdx:
+def parse_table_idx(stream: IO[bytes]) -> TableIdx:
     raw_idx = parse_u32(stream)
     return TableIdx(raw_idx)
 
 
-def parse_type_idx(stream: io.BytesIO) -> TypeIdx:
+def parse_type_idx(stream: IO[bytes]) -> TypeIdx:
     raw_idx = parse_u32(stream)
     return TypeIdx(raw_idx)

--- a/wasm/parsers/instructions.py
+++ b/wasm/parsers/instructions.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.exceptions import (
     MalformedModule,
@@ -27,7 +27,7 @@ from .variable import (
 )
 
 
-def parse_instruction(stream: io.BytesIO) -> Instruction:
+def parse_instruction(stream: IO[bytes]) -> Instruction:
     opcode_byte = stream.read(1)
 
     try:

--- a/wasm/parsers/integers.py
+++ b/wasm/parsers/integers.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm import (
     constants,
@@ -23,7 +23,7 @@ from .leb128 import (
 )
 
 
-def parse_s32(stream: io.BytesIO) -> SInt32:
+def parse_s32(stream: IO[bytes]) -> SInt32:
     start_pos = stream.tell()
     value = parse_signed_leb128(stream)
     end_pos = stream.tell()
@@ -48,7 +48,7 @@ def parse_s32(stream: io.BytesIO) -> SInt32:
         raise Exception("Invariant")
 
 
-def parse_s64(stream: io.BytesIO) -> SInt64:
+def parse_s64(stream: IO[bytes]) -> SInt64:
     start_pos = stream.tell()
     value = parse_signed_leb128(stream)
     end_pos = stream.tell()
@@ -73,7 +73,7 @@ def parse_s64(stream: io.BytesIO) -> SInt64:
         raise Exception("Invariant")
 
 
-def parse_u32(stream: io.BytesIO) -> UInt32:
+def parse_u32(stream: IO[bytes]) -> UInt32:
     start_pos = stream.tell()
     value = parse_unsigned_leb128(stream)
     end_pos = stream.tell()
@@ -98,7 +98,7 @@ def parse_u32(stream: io.BytesIO) -> UInt32:
         raise Exception("Invariant")
 
 
-def parse_u64(stream: io.BytesIO) -> UInt64:
+def parse_u64(stream: IO[bytes]) -> UInt64:
     start_pos = stream.tell()
     value = parse_unsigned_leb128(stream)
     end_pos = stream.tell()
@@ -123,13 +123,13 @@ def parse_u64(stream: io.BytesIO) -> UInt64:
         raise Exception("Invariant")
 
 
-def parse_i32(stream: io.BytesIO) -> UInt32:
+def parse_i32(stream: IO[bytes]) -> UInt32:
     value_s = parse_s32(stream)
     value = s32_to_u32(value_s)
     return value
 
 
-def parse_i64(stream: io.BytesIO) -> UInt64:
+def parse_i64(stream: IO[bytes]) -> UInt64:
     value_s = parse_s64(stream)
     value = s64_to_u64(value_s)
     return value

--- a/wasm/parsers/leb128.py
+++ b/wasm/parsers/leb128.py
@@ -1,9 +1,9 @@
 import functools
-import io
 import itertools
 import math
 import operator
 from typing import (
+    IO,
     Iterable,
 )
 
@@ -15,7 +15,7 @@ SIGN_MASK = 2**6
 REMOVE_SIGN_MASK = 2**6 - 1
 
 
-def parse_signed_leb128(stream: io.BytesIO) -> int:
+def parse_signed_leb128(stream: IO[bytes]) -> int:
     """
     https://en.wikipedia.org/wiki/LEB128
     """
@@ -39,7 +39,7 @@ LOW_MASK = 2**7 - 1
 HIGH_MASK = 2**7
 
 
-def parse_unsigned_leb128(stream: io.BytesIO) -> int:
+def parse_unsigned_leb128(stream: IO[bytes]) -> int:
     """
     https://en.wikipedia.org/wiki/LEB128
     """
@@ -55,7 +55,7 @@ def parse_unsigned_leb128(stream: io.BytesIO) -> int:
 SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
 
 
-def _parse_unsigned_leb128(stream: io.BytesIO) -> Iterable[int]:
+def _parse_unsigned_leb128(stream: IO[bytes]) -> Iterable[int]:
     for shift in itertools.count(0, 7):
         if shift > SHIFT_64_BIT_MAX:
             raise Exception("TODO: better exception msg: Integer is too large...")

--- a/wasm/parsers/limits.py
+++ b/wasm/parsers/limits.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     Limits,
@@ -15,7 +15,7 @@ from .integers import (
 )
 
 
-def parse_limits(stream: io.BytesIO) -> Limits:
+def parse_limits(stream: IO[bytes]) -> Limits:
     flag = parse_single_byte(stream)
 
     if flag == 0x0:

--- a/wasm/parsers/magic.py
+++ b/wasm/parsers/magic.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Tuple,
 )
 
@@ -17,7 +17,7 @@ from .byte import (
 MAGIC = (UInt8(0x00), UInt8(0x61), UInt8(0x73), UInt8(0x6D))
 
 
-def parse_magic(stream: io.BytesIO) -> Tuple[UInt8, UInt8, UInt8, UInt8]:
+def parse_magic(stream: IO[bytes]) -> Tuple[UInt8, UInt8, UInt8, UInt8]:
     """
     https://webassembly.github.io/spec/core/bikeshed/index.html#binary-magic
     """

--- a/wasm/parsers/memory.py
+++ b/wasm/parsers/memory.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     Memory,
@@ -27,7 +27,7 @@ from .null import (
 
 
 def parse_memory_instruction(opcode: BinaryOpcode,
-                             stream: io.BytesIO) -> Instruction:
+                             stream: IO[bytes]) -> Instruction:
     if opcode.is_memory_access:
         memarg = parse_memarg(stream)
 
@@ -42,17 +42,17 @@ def parse_memory_instruction(opcode: BinaryOpcode,
         raise Exception("Invariant")
 
 
-def parse_memarg(stream: io.BytesIO) -> MemoryArg:
+def parse_memarg(stream: IO[bytes]) -> MemoryArg:
     align = parse_u32(stream)
     offset = parse_u32(stream)
     return MemoryArg(offset, align)
 
 
-def parse_memory_type(stream: io.BytesIO) -> MemoryType:
+def parse_memory_type(stream: IO[bytes]) -> MemoryType:
     limits = parse_limits(stream)
     return MemoryType(limits.min, limits.max)
 
 
-def parse_memory(stream: io.BytesIO) -> Memory:
+def parse_memory(stream: IO[bytes]) -> Memory:
     memory_type = parse_memory_type(stream)
     return Memory(memory_type)

--- a/wasm/parsers/module.py
+++ b/wasm/parsers/module.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     Function,
@@ -19,7 +19,7 @@ from .version import (
 )
 
 
-def parse_module(stream: io.BytesIO) -> Module:
+def parse_module(stream: IO[bytes]) -> Module:
     # `parse_magic` both parses and validates the 4-byte *magic* preamble.
     # Curretly we simply discard this value.
     parse_magic(stream)

--- a/wasm/parsers/mutability.py
+++ b/wasm/parsers/mutability.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     Mutability,
@@ -12,7 +12,7 @@ from .byte import (
 )
 
 
-def parse_mut(stream: io.BytesIO) -> Mutability:
+def parse_mut(stream: IO[bytes]) -> Mutability:
     byte = parse_single_byte(stream)
 
     try:

--- a/wasm/parsers/null.py
+++ b/wasm/parsers/null.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.exceptions import (
     MalformedModule,
@@ -6,7 +6,7 @@ from wasm.exceptions import (
 )
 
 
-def parse_null_byte(stream: io.BytesIO) -> None:
+def parse_null_byte(stream: IO[bytes]) -> None:
     byte = stream.read(1)
     if byte == b'\x00':
         return

--- a/wasm/parsers/numeric.py
+++ b/wasm/parsers/numeric.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.instructions import (
     BinOp,
@@ -33,7 +33,7 @@ from .integers import (
 
 
 def parse_numeric_instruction(opcode: BinaryOpcode,
-                              stream: io.BytesIO) -> Instruction:
+                              stream: IO[bytes]) -> Instruction:
     if opcode.is_numeric_constant:
         return parse_numeric_constant_instruction(opcode, stream)
     elif opcode.is_relop:
@@ -51,7 +51,7 @@ def parse_numeric_instruction(opcode: BinaryOpcode,
 
 
 def parse_numeric_constant_instruction(opcode: BinaryOpcode,
-                                       stream: io.BytesIO) -> Instruction:
+                                       stream: IO[bytes]) -> Instruction:
     if opcode is BinaryOpcode.I32_CONST:
         return I32Const.from_opcode(opcode, parse_i32(stream))
     elif opcode is BinaryOpcode.I64_CONST:

--- a/wasm/parsers/parametric.py
+++ b/wasm/parsers/parametric.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.instructions import (
     Drop,
@@ -11,7 +11,7 @@ from wasm.opcodes import (
 
 
 def parse_parametric_instruction(opcode: BinaryOpcode,
-                                 stream: io.BytesIO) -> Instruction:
+                                 stream: IO[bytes]) -> Instruction:
     if opcode is BinaryOpcode.DROP:
         return Drop()
     elif opcode is BinaryOpcode.SELECT:

--- a/wasm/parsers/sections.py
+++ b/wasm/parsers/sections.py
@@ -2,6 +2,7 @@ import functools
 import io
 import logging
 from typing import (
+    IO,
     Any,
     Callable,
     Dict,
@@ -226,7 +227,7 @@ def normalize_sections(sections: Tuple[SECTION_TYPES, ...]) -> T_SECTIONS:
     )
 
 
-def parse_sections(stream: io.BytesIO) -> T_SECTIONS:
+def parse_sections(stream: IO[bytes]) -> T_SECTIONS:
     sections = tuple(_parse_sections(stream))
     return normalize_sections(sections)
 
@@ -241,7 +242,7 @@ def _next_empty_section(section_id: UInt8,
             break
 
 
-def _parse_sections(stream: io.BytesIO) -> Iterable[Any]:
+def _parse_sections(stream: IO[bytes]) -> Iterable[Any]:
     start_pos = stream.tell()
     end_pos = stream.seek(0, 2)
     stream.seek(start_pos)
@@ -293,10 +294,10 @@ def _parse_sections(stream: io.BytesIO) -> Iterable[Any]:
         yield empty_section
 
 
-def validate_section_length(parser_fn: Callable[[io.BytesIO], TReturn]
-                            ) -> Callable[[io.BytesIO], TReturn]:
+def validate_section_length(parser_fn: Callable[[IO[bytes]], TReturn]
+                            ) -> Callable[[IO[bytes]], TReturn]:
     @functools.wraps(parser_fn)
-    def parse_and_validate_length_fn(stream: io.BytesIO) -> TReturn:
+    def parse_and_validate_length_fn(stream: IO[bytes]) -> TReturn:
         # Note: Section parsers all operate under the assumption that their `stream`
         # contains **only** the bytes for the given section.  It follows that
         # successful parsing for any section **must** consume the full stream.
@@ -328,7 +329,7 @@ def validate_section_length(parser_fn: Callable[[io.BytesIO], TReturn]
 # Custom
 #
 @validate_section_length
-def parse_custom_section(stream: io.BytesIO) -> CustomSection:
+def parse_custom_section(stream: IO[bytes]) -> CustomSection:
     name = parse_text(stream)
     # Note that this **requires** that the main section parser feed this parser
     # a stream that **only** contains the section data since it blindly reads
@@ -342,7 +343,7 @@ def parse_custom_section(stream: io.BytesIO) -> CustomSection:
 # Type (1)
 #
 @validate_section_length
-def parse_type_section(stream: io.BytesIO) -> TypeSection:
+def parse_type_section(stream: IO[bytes]) -> TypeSection:
     return TypeSection(parse_vector(parse_function_type, stream))
 
 
@@ -350,7 +351,7 @@ def parse_type_section(stream: io.BytesIO) -> TypeSection:
 # Import (2)
 #
 @validate_section_length
-def parse_import_section(stream: io.BytesIO) -> ImportSection:
+def parse_import_section(stream: IO[bytes]) -> ImportSection:
     return ImportSection(parse_vector(parse_import, stream))
 
 
@@ -358,7 +359,7 @@ def parse_import_section(stream: io.BytesIO) -> ImportSection:
 # Function (3)
 #
 @validate_section_length
-def parse_function_section(stream: io.BytesIO) -> FunctionSection:
+def parse_function_section(stream: IO[bytes]) -> FunctionSection:
     return FunctionSection(parse_vector(parse_type_idx, stream))
 
 
@@ -366,7 +367,7 @@ def parse_function_section(stream: io.BytesIO) -> FunctionSection:
 # Table (4)
 #
 @validate_section_length
-def parse_table_section(stream: io.BytesIO) -> TableSection:
+def parse_table_section(stream: IO[bytes]) -> TableSection:
     return TableSection(parse_vector(parse_table, stream))
 
 
@@ -374,7 +375,7 @@ def parse_table_section(stream: io.BytesIO) -> TableSection:
 # Memory (5)
 #
 @validate_section_length
-def parse_memory_section(stream: io.BytesIO) -> MemorySection:
+def parse_memory_section(stream: IO[bytes]) -> MemorySection:
     return MemorySection(parse_vector(parse_memory, stream))
 
 
@@ -382,7 +383,7 @@ def parse_memory_section(stream: io.BytesIO) -> MemorySection:
 # Global (6)
 #
 @validate_section_length
-def parse_global_section(stream: io.BytesIO) -> GlobalSection:
+def parse_global_section(stream: IO[bytes]) -> GlobalSection:
     return GlobalSection(parse_vector(parse_global, stream))
 
 
@@ -390,7 +391,7 @@ def parse_global_section(stream: io.BytesIO) -> GlobalSection:
 # Export (7)
 #
 @validate_section_length
-def parse_export_section(stream: io.BytesIO) -> ExportSection:
+def parse_export_section(stream: IO[bytes]) -> ExportSection:
     return ExportSection(parse_vector(parse_export, stream))
 
 
@@ -398,7 +399,7 @@ def parse_export_section(stream: io.BytesIO) -> ExportSection:
 # Start (8)
 #
 @validate_section_length
-def parse_start_section(stream: io.BytesIO) -> StartSection:
+def parse_start_section(stream: IO[bytes]) -> StartSection:
     return StartSection(parse_start_function(stream))
 
 
@@ -406,7 +407,7 @@ def parse_start_section(stream: io.BytesIO) -> StartSection:
 # Element Segment (9)
 #
 @validate_section_length
-def parse_element_segment_section(stream: io.BytesIO) -> ElementSegmentSection:
+def parse_element_segment_section(stream: IO[bytes]) -> ElementSegmentSection:
     return ElementSegmentSection(parse_vector(parse_element_segment, stream))
 
 
@@ -414,7 +415,7 @@ def parse_element_segment_section(stream: io.BytesIO) -> ElementSegmentSection:
 # Code (10)
 #
 @validate_section_length
-def parse_code_section(stream: io.BytesIO) -> CodeSection:
+def parse_code_section(stream: IO[bytes]) -> CodeSection:
     return CodeSection(parse_vector(parse_code, stream))
 
 
@@ -422,7 +423,7 @@ def parse_code_section(stream: io.BytesIO) -> CodeSection:
 # Data (11)
 #
 @validate_section_length
-def parse_data_segment_section(stream: io.BytesIO) -> DataSegmentSection:
+def parse_data_segment_section(stream: IO[bytes]) -> DataSegmentSection:
     return DataSegmentSection(parse_vector(parse_data_segment, stream))
 
 

--- a/wasm/parsers/tables.py
+++ b/wasm/parsers/tables.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Type,
 )
 
@@ -20,7 +20,7 @@ from .limits import (
 )
 
 
-def parse_table_element_type(stream: io.BytesIO) -> Type[FunctionAddress]:
+def parse_table_element_type(stream: IO[bytes]) -> Type[FunctionAddress]:
     type_flag = parse_single_byte(stream)
 
     if type_flag == 0x70:
@@ -31,12 +31,12 @@ def parse_table_element_type(stream: io.BytesIO) -> Type[FunctionAddress]:
         )
 
 
-def parse_table_type(stream: io.BytesIO) -> TableType:
+def parse_table_type(stream: IO[bytes]) -> TableType:
     element_type = parse_table_element_type(stream)
     limits = parse_limits(stream)
     return TableType(limits, element_type)
 
 
-def parse_table(stream: io.BytesIO) -> Table:
+def parse_table(stream: IO[bytes]) -> Table:
     table_type = parse_table_type(stream)
     return Table(table_type)

--- a/wasm/parsers/text.py
+++ b/wasm/parsers/text.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.exceptions import (
     MalformedModule,
@@ -10,7 +10,7 @@ from .integers import (
 )
 
 
-def parse_text(stream: io.BytesIO) -> str:
+def parse_text(stream: IO[bytes]) -> str:
     encoded_name_length = parse_u32(stream)
     encoded_name = stream.read(encoded_name_length)
 

--- a/wasm/parsers/valtype.py
+++ b/wasm/parsers/valtype.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.datatypes import (
     ValType,
@@ -12,7 +12,7 @@ from .byte import (
 )
 
 
-def parse_valtype(stream: io.BytesIO) -> ValType:
+def parse_valtype(stream: IO[bytes]) -> ValType:
     byte = parse_single_byte(stream)
 
     try:

--- a/wasm/parsers/variable.py
+++ b/wasm/parsers/variable.py
@@ -1,4 +1,4 @@
-import io
+from typing import IO
 
 from wasm.instructions import (
     GlobalOp,
@@ -16,7 +16,7 @@ from .indices import (
 
 
 def parse_variable_instruction(opcode: BinaryOpcode,
-                               stream: io.BytesIO) -> Instruction:
+                               stream: IO[bytes]) -> Instruction:
     if opcode.is_local:
         local_idx = parse_local_idx(stream)
         return LocalOp.from_opcode(opcode, local_idx)

--- a/wasm/parsers/vector.py
+++ b/wasm/parsers/vector.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Callable,
     Iterable,
     Tuple,
@@ -20,8 +20,8 @@ from .integers import (
 TItem = TypeVar('TItem')
 
 
-def parse_vector(sub_parser: Callable[[io.BytesIO], TItem],
-                 stream: io.BytesIO,
+def parse_vector(sub_parser: Callable[[IO[bytes]], TItem],
+                 stream: IO[bytes],
                  ) -> Tuple[TItem, ...]:
     vector_size = parse_u32(stream)
     try:
@@ -30,9 +30,9 @@ def parse_vector(sub_parser: Callable[[io.BytesIO], TItem],
         raise ParseError(f"Error parsing vector: {err}") from err
 
 
-def _parse_vector(sub_parser: Callable[[io.BytesIO], TItem],
+def _parse_vector(sub_parser: Callable[[IO[bytes]], TItem],
                   vector_size: UInt32,
-                  stream: io.BytesIO,
+                  stream: IO[bytes],
                   ) -> Iterable[TItem]:
     for _ in range(vector_size):
         yield sub_parser(stream)

--- a/wasm/parsers/version.py
+++ b/wasm/parsers/version.py
@@ -1,5 +1,5 @@
-import io
 from typing import (
+    IO,
     Tuple,
 )
 
@@ -22,7 +22,7 @@ KNOWN_VERSIONS = {
 }
 
 
-def parse_version(stream: io.BytesIO) -> Tuple[UInt8, UInt8, UInt8, UInt8]:
+def parse_version(stream: IO[bytes]) -> Tuple[UInt8, UInt8, UInt8, UInt8]:
     """
     https://webassembly.github.io/spec/core/bikeshed/index.html#binary-version
     """


### PR DESCRIPTION
## What was wrong?

All of the parsers were written using the `io.BytesIO` type when in fact we needed to use [`typing.IO[bytes]`](https://docs.python.org/3.5/library/typing.html#typing.io) to be able to support arbitrary file-like objects.

## How was it fixed?

Converted type hints for all parsers to use `IO[bytes]`

#### Cute Animal Picture

![cone-of-shame-dog-vs-gloating-dog](https://user-images.githubusercontent.com/824194/52441932-38c4b580-2adf-11e9-9b2a-4e9851cc0428.jpg)

