### PR TITLE
Test values right at signed integer boundaries

### DIFF
--- a/tests/core/numeric-utils/test_signed_to_unsigned.py
+++ b/tests/core/numeric-utils/test_signed_to_unsigned.py
@@ -20,8 +20,12 @@ from wasm._utils.numeric import (
         (s64_to_u64, 0, 0),
         (s32_to_u32, 1, 1),
         (s64_to_u64, 1, 1),
+        (s32_to_u32, -1, constants.UINT32_MAX),
+        (s64_to_u64, -1, constants.UINT64_MAX),
         (s32_to_u32, constants.SINT32_MIN, constants.SINT32_CEIL),
         (s64_to_u64, constants.SINT64_MIN, constants.SINT64_CEIL),
+        (s32_to_u32, constants.SINT32_MAX, constants.SINT32_MAX),
+        (s64_to_u64, constants.SINT64_MAX, constants.SINT64_MAX),
     ),
 )
 def test_signed_to_unsigned(convert_fn, value, expected):

--- a/tests/core/numeric-utils/test_unsigned_to_signed.py
+++ b/tests/core/numeric-utils/test_unsigned_to_signed.py
@@ -20,8 +20,12 @@ from wasm._utils.numeric import (
         (u64_to_s64, 0, 0),
         (u32_to_s32, 1, 1),
         (u64_to_s64, 1, 1),
+        (u32_to_s32, constants.UINT32_MAX, -1),
+        (u64_to_s64, constants.UINT64_MAX, -1),
         (u32_to_s32, constants.SINT32_CEIL, constants.SINT32_MIN),
         (u64_to_s64, constants.SINT64_CEIL, constants.SINT64_MIN),
+        (u32_to_s32, constants.SINT32_MAX, constants.SINT32_MAX),
+        (u64_to_s64, constants.SINT64_MAX, constants.SINT64_MAX),
     ),
 )
 def test_unsigned_to_signed(convert_fn, value, expected):


### PR DESCRIPTION
## What was wrong?

Missing some useful test cases to ensure the conversion utils for signed and unsigned integers behave correctly.

## How was it fixed?

Added tests for values just inside range boundaries.

#### Cute Animal Picture

![ad_226867617](https://user-images.githubusercontent.com/824194/52446095-403d8c00-2aea-11e9-9db0-28f00b543b46.jpg)

