### PR TITLE
[WIP] Extract and organize floating point logic functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+def pytest_addoption(parser):
+    parser.addoption("--skip-slow-spec", action="store_true", required=False)

--- a/tests/core/execution/test_configuration_object.py
+++ b/tests/core/execution/test_configuration_object.py
@@ -1,0 +1,247 @@
+import pytest
+
+from wasm.datatypes import (
+    Store,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+    Label,
+)
+
+
+@pytest.fixture
+def config():
+    return Configuration(Store())
+
+
+def test_configuration_frame_stack_size(config):
+    assert config.frame_stack_size == 0
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame_stack_size == 1
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame_stack_size == 2
+
+    assert config.pop_frame() is frame_b
+    assert config.pop_frame() is frame_a
+
+    assert config.frame_stack_size == 0
+
+
+def test_configuration_has_active_frame(config):
+    assert config.has_active_frame is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_frame is True
+
+    config.pop_frame()
+
+    assert config.has_active_frame is False
+
+
+def test_configuration_frame_property(config):
+    with pytest.raises(IndexError):
+        config.frame
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.frame is frame_a
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.frame is frame_b
+
+    assert config.pop_frame() is frame_b
+
+    assert config.frame is frame_a
+
+
+def test_configuration_has_active_label(config):
+    assert config.has_active_label is False
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.has_active_label is False
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.has_active_label is True
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.has_active_label is False
+
+    # now pop the frame and should have an active label
+    config.pop_frame()
+
+    assert config.has_active_label is True
+
+    config.pop_label()
+
+    assert config.has_active_label is False
+
+
+def test_configuration_active_label_property(config):
+    with pytest.raises(IndexError):
+        config.active_label
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.active_label is label_a
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.active_label is label_b
+
+    # now push a new frame and there should not be an active label
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    with pytest.raises(IndexError):
+        config.active_label
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.active_label is label_c
+
+
+def test_configuration_instructions_property(config):
+    with pytest.raises(IndexError):
+        config.instructions
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.instructions is frame_a.instructions
+
+    label_a = Label(0, [], False)
+    config.push_label(label_a)
+
+    assert config.instructions is label_a.instructions
+
+    frame_b = Frame(None, [], [], 0)
+    config.push_frame(frame_b)
+
+    assert config.instructions is frame_b.instructions
+
+    label_b = Label(0, [], False)
+    config.push_label(label_b)
+
+    assert config.instructions is label_b.instructions
+
+    label_c = Label(0, [], False)
+    config.push_label(label_c)
+
+    assert config.instructions is label_c.instructions
+
+
+def test_configuration_push_and_pop_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    assert config.operand_stack_size == 0
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.operand_stack_size == 6
+
+    assert config.pop_operand() == 5
+    assert config.operand_stack_size == 5
+    assert config.pop2_operands() == (4, 3)
+    assert config.operand_stack_size == 3
+    assert config.pop3_operands() == (2, 1, 0)
+    assert config.operand_stack_size == 0
+
+
+def test_configuration_push_and_pop_u32_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u32() == 5
+    assert config.pop2_u32() == (4, 3)
+    assert config.pop3_u32() == (2, 1, 0)
+
+
+def test_configuration_push_and_pop_u64_from_operand_stack(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame_a = Frame(None, [], [], 0)
+    config.push_frame(frame_a)
+
+    config.push_operand(0)
+    config.push_operand(1)
+    config.push_operand(2)
+    config.push_operand(3)
+    config.push_operand(4)
+    config.push_operand(5)
+
+    assert config.pop_u64() == 5
+    assert config.pop2_u64() == (4, 3)
+    assert config.pop3_u64() == (2, 1, 0)
+
+
+def test_configuration_get_label_by_idx(config):
+    with pytest.raises(IndexError):
+        config.push_operand(0)
+
+    frame = Frame(None, [], [], 0)
+    config.push_frame(frame)
+
+    label_3 = Label(0, [], False)
+    config.push_label(label_3)
+    label_2 = Label(0, [], False)
+    config.push_label(label_2)
+    label_1 = Label(0, [], False)
+    config.push_label(label_1)
+    label_0 = Label(0, [], False)
+    config.push_label(label_0)
+
+    assert config.get_by_label_idx(0) is label_0
+    assert config.get_by_label_idx(1) is label_1
+    assert config.get_by_label_idx(2) is label_2
+    assert config.get_by_label_idx(3) is label_3
+
+    with pytest.raises(IndexError):
+        assert config.get_by_label_idx(4)

--- a/tests/core/numeric-logic/test_floating_point_comparisons.py
+++ b/tests/core/numeric-logic/test_floating_point_comparisons.py
@@ -1,0 +1,123 @@
+import itertools
+import math
+
+import pytest
+
+from wasm.datatypes import (
+    Store,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+)
+from wasm.instructions import (
+    RelOp,
+    End,
+)
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+
+@pytest.fixture
+def config():
+    return Configuration(Store())
+
+
+@pytest.mark.parametrize(
+    "opcode,operands_and_expected",
+    itertools.chain(
+        itertools.product(
+            (BinaryOpcode.F32_LT, BinaryOpcode.F64_LT),
+            (
+                ((0.0, 0.0), (0,)),
+                ((1.0, 1.0), (0,)),
+                # nans
+                ((math.nan, 0), (0,)),
+                ((0.0, math.nan), (0,)),
+                ((math.nan, math.nan), (0,)),
+                # a is inf
+                ((math.inf, 0.0), (0,)),
+                ((math.inf, math.inf), (0,)),
+                # a is -inf
+                ((-math.inf, 0.0), (1,)),
+                ((-math.inf, -math.inf), (1,)),
+                # b is inf
+                ((0.0, math.inf), (1,)),
+                # b is -inf
+                ((0.0, -math.inf), (0,)),
+            ),
+        ),
+        itertools.product(
+            (BinaryOpcode.F32_GT, BinaryOpcode.F64_GT),
+            (
+                ((0.0, 0.0), (0,)),
+                ((1.0, 1.0), (0,)),
+                # nans
+                ((math.nan, 0.0), (0,)),
+                ((0.0, math.nan), (0,)),
+                ((math.nan, math.nan), (0,)),
+                # a is inf
+                ((math.inf, 0.0), (1,)),
+                ((math.inf, math.inf), (1,)),
+                # a is -inf
+                ((-math.inf, 0.0), (0,)),
+                ((-math.inf, -math.inf), (0,)),
+                # b is inf
+                ((0.0, math.inf), (0,)),
+                # b is -inf
+                ((0.0, -math.inf), (1,)),
+            ),
+        ),
+        itertools.product(
+            (BinaryOpcode.F32_LE, BinaryOpcode.F64_LE),
+            (
+                ((0.0, 0.0), (1,)),
+                ((1.0, 1.0), (1,)),
+                # nans
+                ((math.nan, 0), (0,)),
+                ((0.0, math.nan), (0,)),
+                ((math.nan, math.nan), (0,)),
+                # a is inf
+                ((math.inf, 0.0), (0,)),
+                ((math.inf, math.inf), (0,)),
+                # a is -inf
+                ((-math.inf, 0.0), (1,)),
+                ((-math.inf, -math.inf), (1,)),
+                # b is inf
+                ((0.0, math.inf), (1,)),
+                # b is -inf
+                ((0.0, -math.inf), (0,)),
+            ),
+        ),
+        itertools.product(
+            (BinaryOpcode.F32_GE, BinaryOpcode.F64_GE),
+            (
+                ((0.0, 0.0), (1,)),
+                ((1.0, 1.0), (1,)),
+                # nans
+                ((math.nan, 0.0), (0,)),
+                ((0.0, math.nan), (0,)),
+                ((math.nan, math.nan), (0,)),
+                # a is inf
+                ((math.inf, 0.0), (1,)),
+                ((math.inf, math.inf), (1,)),
+                # a is -inf
+                ((-math.inf, 0.0), (0,)),
+                ((-math.inf, -math.inf), (0,)),
+                # b is inf
+                ((0.0, math.inf), (0,)),
+                # b is -inf
+                ((0.0, -math.inf), (1,)),
+            ),
+        ),
+    ),
+)
+def test_float_comparison_operations(config, opcode, operands_and_expected):
+    operands, expected = operands_and_expected
+    frame = Frame(None, [], (RelOp.from_opcode(opcode), End()), len(expected))
+    config.push_frame(frame)
+    config.extend_operands(operands)
+
+    results = config.execute()
+    assert results == expected

--- a/tests/spec/test_spec.py
+++ b/tests/spec/test_spec.py
@@ -16,9 +16,11 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 def pytest_generate_tests(metafunc):
+    skip_slow_spec = metafunc.config.getoption('skip_slow_spec')
     generate_fixture_tests(
         metafunc=metafunc,
         fixtures_dir=FIXTURES_DIR,
+        skip_slow=skip_slow_spec,
     )
 
 

--- a/wasm/__init__.py
+++ b/wasm/__init__.py
@@ -4,8 +4,3 @@ from .datatypes import (  # noqa: F401
 from .execution import (  # noqa: F401
     Runtime,
 )
-from .main import (  # noqa: F401
-    decode_module,
-    invoke_func,
-    validate_module,
-)

--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -1,6 +1,7 @@
 from typing import (
     NamedTuple,
     Union,
+    cast,
 )
 
 from .addresses import (
@@ -78,13 +79,29 @@ class ExportInstance(NamedTuple):
         return isinstance(self.value, FunctionAddress)
 
     @property
+    def function_address(self) -> FunctionAddress:
+        return cast(FunctionAddress, self.value)
+
+    @property
     def is_global(self):
         return isinstance(self.value, GlobalAddress)
+
+    @property
+    def global_address(self) -> GlobalAddress:
+        return cast(GlobalAddress, self.value)
 
     @property
     def is_memory(self):
         return isinstance(self.value, MemoryAddress)
 
     @property
+    def memory_address(self) -> MemoryAddress:
+        return cast(MemoryAddress, self.value)
+
+    @property
     def is_table(self):
         return isinstance(self.value, TableAddress)
+
+    @property
+    def table_address(self) -> TableAddress:
+        return cast(TableAddress, self.value)

--- a/wasm/datatypes/function.py
+++ b/wasm/datatypes/function.py
@@ -1,8 +1,13 @@
 from abc import ABC
 from typing import (
     TYPE_CHECKING,
+    Callable,
     NamedTuple,
     Tuple,
+)
+
+from wasm.typing import (
+    TValue,
 )
 
 from .indices import (
@@ -17,8 +22,8 @@ if TYPE_CHECKING:
     from wasm.instructions import (  # noqa: F401
         BaseInstruction,
     )
-    from wasm.typing import (  # noqa: F401
-        HostFunctionCallable,
+    from wasm.execution import (  # noqa: F401
+        Configuration,
     )
 
 
@@ -49,9 +54,12 @@ class BaseFunctionInstance(ABC):
     type: FunctionType
 
 
+HostFunctionCallable = Callable[['Configuration', Tuple[TValue, ...]], Tuple[TValue, ...]]
+
+
 class HostFunction(NamedTuple):
     type: FunctionType
-    hostcode: 'HostFunctionCallable'
+    hostcode: HostFunctionCallable
 
 
 class StartFunction(NamedTuple):

--- a/wasm/datatypes/memory.py
+++ b/wasm/datatypes/memory.py
@@ -3,6 +3,13 @@ from typing import (
     Optional,
 )
 
+from wasm import (
+    constants,
+)
+from wasm.exceptions import (
+    Trap,
+    ValidationError,
+)
 from wasm.typing import (
     UInt32,
 )
@@ -23,3 +30,39 @@ class Memory(NamedTuple):
 class MemoryInstance(NamedTuple):
     data: bytearray
     max: Optional[UInt32]
+
+    @property
+    def num_pages(self) -> UInt32:
+        return UInt32(len(self.data) // constants.PAGE_SIZE_64K)
+
+    def read(self, location: UInt32, size: UInt32) -> bytes:
+        if location + size > len(self.data):
+            raise Trap(
+                f"Attempt to read from out of bounds memory location: {location + size} "
+                f"> {len(self.data)}"
+            )
+        return self.data[location:location + size]
+
+    def write(self, location: UInt32, value: bytes) -> None:
+        if location + len(value) > len(self.data):
+            raise Trap(
+                f"Attempt to write to out of bounds memory location: "
+                f"{location + len(value)} "
+                f"> {len(self.data)}"
+            )
+        self.data[location: location + len(value)] = value
+
+    def grow(self, num_pages: UInt32) -> UInt32:
+        new_num_pages = num_pages + len(self.data) // constants.PAGE_SIZE_64K
+        if new_num_pages >= constants.UINT16_CEIL:
+            raise ValidationError(
+                f"Memory length exceeds u16 bounds: {new_num_pages} > {constants.UINT16_CEIL}"
+            )
+        elif self.max is not None and self.max < new_num_pages:
+            raise ValidationError(
+                f"Memory length exceeds maximum memory size bounds: {new_num_pages} > "
+                f"{self.max}"
+            )
+
+        self.data.extend(bytearray(num_pages * constants.PAGE_SIZE_64K))
+        return UInt32(new_num_pages)

--- a/wasm/datatypes/store.py
+++ b/wasm/datatypes/store.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Iterable,
     List,
     Tuple,
@@ -12,7 +13,6 @@ from wasm.exceptions import (
     ValidationError,
 )
 from wasm.typing import (
-    HostFunctionCallable,
     TValue,
     UInt32,
 )
@@ -27,6 +27,7 @@ from .function import (
     Function,
     FunctionType,
     HostFunction,
+    HostFunctionCallable,
 )
 from .globals import (
     GlobalInstance,
@@ -50,6 +51,12 @@ from .table import (
     TableInstance,
     TableType,
 )
+
+if TYPE_CHECKING:
+    from wasm.execution import (  # noqa: F401
+        Configuration,
+    )
+
 
 TAddress = Union[FunctionAddress, GlobalAddress, MemoryAddress, TableAddress]
 TExtern = Union[FunctionType, TableType, MemoryType, GlobalType]

--- a/wasm/datatypes/valtype.py
+++ b/wasm/datatypes/valtype.py
@@ -11,9 +11,9 @@ from wasm.typing import (
     Float32,
     Float64,
     TValue,
+    UInt8,
     UInt32,
     UInt64,
-    UInt8,
 )
 
 from .bit_size import (

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -14,6 +14,7 @@ from wasm.datatypes import (
 )
 from wasm.typing import (
     Float32,
+    Float64,
     TValue,
     UInt32,
     UInt64,
@@ -147,6 +148,21 @@ class BaseConfiguration(ABC):
 
     @abstractmethod
     def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
+        pass
+
+    #
+    # Pop f64
+    #
+    @abstractmethod
+    def pop_f64(self) -> Float64:
+        pass
+
+    @abstractmethod
+    def pop2_f64(self) -> Tuple[Float64, Float64]:
+        pass
+
+    @abstractmethod
+    def pop3_f64(self) -> Tuple[Float64, Float64, Float64]:
         pass
 
     #
@@ -310,6 +326,20 @@ class Configuration(BaseConfiguration):
     def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
         a, b, c = self.frame.active_operand_stack.pop3()
         return cast(Float32, a), cast(Float32, b), cast(Float32, c)
+
+    #
+    # Pop f64
+    #
+    def pop_f64(self) -> Float64:
+        return cast(Float64, self.frame.active_operand_stack.pop())
+
+    def pop2_f64(self) -> Tuple[Float64, Float64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(Float64, a), cast(Float64, b)
+
+    def pop3_f64(self) -> Tuple[Float64, Float64, Float64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(Float64, a), cast(Float64, b), cast(Float64, c)
 
     #
     # Frames

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -196,11 +196,17 @@ class Configuration(BaseConfiguration):
     def execute(self) -> Tuple[TValue, ...]:
         # TODO: unwrap import once logic functions move out of wasm.main
         from wasm.main import opcode2exec
+        from wasm.logic import OPCODE_TO_LOGIC_FN
 
         while self.has_active_frame:
             instruction = next(self.instructions)
 
-            logic_fn = opcode2exec[instruction.opcode][0]
+            if instruction.opcode in OPCODE_TO_LOGIC_FN:
+                assert instruction.opcode not in opcode2exec
+                logic_fn = OPCODE_TO_LOGIC_FN[instruction.opcode]
+            else:
+                logic_fn = opcode2exec[instruction.opcode][0]
+
             logic_fn(self)
 
         if len(self.result_stack) > 1:

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -3,7 +3,9 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    Iterable,
     Tuple,
+    cast,
 )
 
 from wasm.datatypes import (
@@ -11,7 +13,10 @@ from wasm.datatypes import (
     Store,
 )
 from wasm.typing import (
+    Float32,
     TValue,
+    UInt32,
+    UInt64,
 )
 
 from .instructions import (
@@ -62,6 +67,17 @@ class BaseConfiguration(ABC):
         pass
 
     #
+    # Results
+    #
+    @abstractmethod
+    def push_result(self, value: TValue) -> None:
+        pass
+
+    @abstractmethod
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        pass
+
+    #
     # Operands
     #
     @property
@@ -74,6 +90,10 @@ class BaseConfiguration(ABC):
         pass
 
     @abstractmethod
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        pass
+
+    @abstractmethod
     def pop_operand(self) -> TValue:
         pass
 
@@ -83,6 +103,50 @@ class BaseConfiguration(ABC):
 
     @abstractmethod
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
+        pass
+
+    #
+    # Pop u32
+    #
+    @abstractmethod
+    def pop_u32(self) -> UInt32:
+        pass
+
+    @abstractmethod
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        pass
+
+    @abstractmethod
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        pass
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    @abstractmethod
+    def pop_f32(self) -> Float32:
+        pass
+
+    @abstractmethod
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        pass
+
+    @abstractmethod
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
         pass
 
     #
@@ -169,6 +233,15 @@ class Configuration(BaseConfiguration):
         return self.frame.active_instructions
 
     #
+    # Results
+    #
+    def push_result(self, value: TValue) -> None:
+        self.result_stack.push(value)
+
+    def extend_results(self, values: Iterable[TValue]) -> None:
+        self.result_stack.extend(values)
+
+    #
     # Operands
     #
     @property
@@ -178,6 +251,9 @@ class Configuration(BaseConfiguration):
     def push_operand(self, value: TValue) -> None:
         self.frame.active_operand_stack.push(value)
 
+    def extend_operands(self, values: Iterable[TValue]) -> None:
+        self.frame.active_operand_stack.extend(values)
+
     def pop_operand(self) -> TValue:
         return self.frame.active_operand_stack.pop()
 
@@ -186,6 +262,48 @@ class Configuration(BaseConfiguration):
 
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
         return self.frame.active_operand_stack.pop3()
+
+    #
+    # Pop u32
+    #
+    def pop_u32(self) -> UInt32:
+        return cast(UInt32, self.frame.active_operand_stack.pop())
+
+    def pop2_u32(self) -> Tuple[UInt32, UInt32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt32, a), cast(UInt32, b)
+
+    def pop3_u32(self) -> Tuple[UInt32, UInt32, UInt32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt32, a), cast(UInt32, b), cast(UInt32, c)
+
+    #
+    # Pop u64
+    #
+    def pop_u64(self) -> UInt64:
+        return cast(UInt64, self.frame.active_operand_stack.pop())
+
+    def pop2_u64(self) -> Tuple[UInt64, UInt64]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(UInt64, a), cast(UInt64, b)
+
+    def pop3_u64(self) -> Tuple[UInt64, UInt64, UInt64]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(UInt64, a), cast(UInt64, b), cast(UInt64, c)
+
+    #
+    # Pop f32
+    #
+    def pop_f32(self) -> Float32:
+        return cast(Float32, self.frame.active_operand_stack.pop())
+
+    def pop2_f32(self) -> Tuple[Float32, Float32]:
+        a, b = self.frame.active_operand_stack.pop2()
+        return cast(Float32, a), cast(Float32, b)
+
+    def pop3_f32(self) -> Tuple[Float32, Float32, Float32]:
+        a, b, c = self.frame.active_operand_stack.pop3()
+        return cast(Float32, a), cast(Float32, b), cast(Float32, c)
 
     #
     # Frames

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -8,8 +8,9 @@ from wasm.opcodes import (
     BinaryOpcode,
 )
 
-from .import numeric
 from . import control
+from . import numeric
+from . import variable
 
 if TYPE_CHECKING:
     from wasm.execution import (  # noqa:
@@ -33,11 +34,11 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.CALL_INDIRECT: control.call_indirect_op,
     BinaryOpcode.DROP: control.drop_op,
     BinaryOpcode.SELECT: control.select_op,
-    # BinaryOpcode.GET_LOCAL:
-    # BinaryOpcode.SET_LOCAL:
-    # BinaryOpcode.TEE_LOCAL:
-    # BinaryOpcode.GET_GLOBAL:
-    # BinaryOpcode.SET_GLOBAL:
+    BinaryOpcode.GET_LOCAL: variable.get_local_op,
+    BinaryOpcode.SET_LOCAL: variable.set_local_op,
+    BinaryOpcode.TEE_LOCAL: variable.tee_local_op,
+    BinaryOpcode.GET_GLOBAL: variable.get_global_op,
+    BinaryOpcode.SET_GLOBAL: variable.set_global_op,
     # BinaryOpcode.I32_LOAD:
     # BinaryOpcode.I64_LOAD:
     # BinaryOpcode.F32_LOAD:

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -1,0 +1,194 @@
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Callable,
+)
+
+from wasm.opcodes import (
+    BinaryOpcode,
+)
+
+from . import control
+
+if TYPE_CHECKING:
+    from wasm.execution import (  # noqa:
+        Configuration,
+    )
+
+
+OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
+    BinaryOpcode.UNREACHABLE: control.unreachable_op,
+    BinaryOpcode.NOP: control.nop_op,
+    BinaryOpcode.BLOCK: control.block_op,
+    BinaryOpcode.LOOP: control.loop_op,
+    BinaryOpcode.IF: control.if_op,
+    BinaryOpcode.ELSE: control.else_op,
+    BinaryOpcode.END: control.end_op,
+    BinaryOpcode.BR: control.br_op,
+    BinaryOpcode.BR_IF: control.br_if_op,
+    BinaryOpcode.BR_TABLE: control.br_table_op,
+    BinaryOpcode.RETURN: control.return_op,
+    BinaryOpcode.CALL: control.call_op,
+    BinaryOpcode.CALL_INDIRECT: control.call_indirect_op,
+    BinaryOpcode.DROP: control.drop_op,
+    BinaryOpcode.SELECT: control.select_op,
+    # BinaryOpcode.GET_LOCAL:
+    # BinaryOpcode.SET_LOCAL:
+    # BinaryOpcode.TEE_LOCAL:
+    # BinaryOpcode.GET_GLOBAL:
+    # BinaryOpcode.SET_GLOBAL:
+    # BinaryOpcode.I32_LOAD:
+    # BinaryOpcode.I64_LOAD:
+    # BinaryOpcode.F32_LOAD:
+    # BinaryOpcode.F64_LOAD:
+    # BinaryOpcode.I32_LOAD8_S:
+    # BinaryOpcode.I32_LOAD8_U:
+    # BinaryOpcode.I32_LOAD16_S:
+    # BinaryOpcode.I32_LOAD16_U:
+    # BinaryOpcode.I64_LOAD8_S:
+    # BinaryOpcode.I64_LOAD8_U:
+    # BinaryOpcode.I64_LOAD16_S:
+    # BinaryOpcode.I64_LOAD16_U:
+    # BinaryOpcode.I64_LOAD32_S:
+    # BinaryOpcode.I64_LOAD32_U:
+    # BinaryOpcode.I32_STORE:
+    # BinaryOpcode.I64_STORE:
+    # BinaryOpcode.F32_STORE:
+    # BinaryOpcode.F64_STORE:
+    # BinaryOpcode.I32_STORE8:
+    # BinaryOpcode.I32_STORE16:
+    # BinaryOpcode.I64_STORE8:
+    # BinaryOpcode.I64_STORE16:
+    # BinaryOpcode.I64_STORE32:
+    # BinaryOpcode.MEMORY_SIZE:
+    # BinaryOpcode.MEMORY_GROW:
+    # BinaryOpcode.I32_CONST:
+    # BinaryOpcode.I64_CONST:
+    # BinaryOpcode.F32_CONST:
+    # BinaryOpcode.F64_CONST:
+    # BinaryOpcode.I32_EQZ:
+    # BinaryOpcode.I32_EQ:
+    # BinaryOpcode.I32_NE:
+    # BinaryOpcode.I32_LT_S:
+    # BinaryOpcode.I32_LT_U:
+    # BinaryOpcode.I32_GT_S:
+    # BinaryOpcode.I32_GT_U:
+    # BinaryOpcode.I32_LE_S:
+    # BinaryOpcode.I32_LE_U:
+    # BinaryOpcode.I32_GE_S:
+    # BinaryOpcode.I32_GE_U:
+    # BinaryOpcode.I64_EQZ:
+    # BinaryOpcode.I64_EQ:
+    # BinaryOpcode.I64_NE:
+    # BinaryOpcode.I64_LT_S:
+    # BinaryOpcode.I64_LT_U:
+    # BinaryOpcode.I64_GT_S:
+    # BinaryOpcode.I64_GT_U:
+    # BinaryOpcode.I64_LE_S:
+    # BinaryOpcode.I64_LE_U:
+    # BinaryOpcode.I64_GE_S:
+    # BinaryOpcode.I64_GE_U:
+    # BinaryOpcode.F32_EQ:
+    # BinaryOpcode.F32_NE:
+    # BinaryOpcode.F32_LT:
+    # BinaryOpcode.F32_GT:
+    # BinaryOpcode.F32_LE:
+    # BinaryOpcode.F32_GE:
+    # BinaryOpcode.F64_EQ:
+    # BinaryOpcode.F64_NE:
+    # BinaryOpcode.F64_LT:
+    # BinaryOpcode.F64_GT:
+    # BinaryOpcode.F64_LE:
+    # BinaryOpcode.F64_GE:
+    # BinaryOpcode.I32_CLZ:
+    # BinaryOpcode.I32_CTZ:
+    # BinaryOpcode.I32_POPCNT:
+    # BinaryOpcode.I32_ADD:
+    # BinaryOpcode.I32_SUB:
+    # BinaryOpcode.I32_MUL:
+    # BinaryOpcode.I32_DIV_S:
+    # BinaryOpcode.I32_DIV_U:
+    # BinaryOpcode.I32_REM_S:
+    # BinaryOpcode.I32_REM_U:
+    # BinaryOpcode.I32_AND:
+    # BinaryOpcode.I32_OR:
+    # BinaryOpcode.I32_XOR:
+    # BinaryOpcode.I32_SHL:
+    # BinaryOpcode.I32_SHR_S:
+    # BinaryOpcode.I32_SHR_U:
+    # BinaryOpcode.I32_ROTL:
+    # BinaryOpcode.I32_ROTR:
+    # BinaryOpcode.I64_CLZ:
+    # BinaryOpcode.I64_CTZ:
+    # BinaryOpcode.I64_POPCNT:
+    # BinaryOpcode.I64_ADD:
+    # BinaryOpcode.I64_SUB:
+    # BinaryOpcode.I64_MUL:
+    # BinaryOpcode.I64_DIV_S:
+    # BinaryOpcode.I64_DIV_U:
+    # BinaryOpcode.I64_REM_S:
+    # BinaryOpcode.I64_REM_U:
+    # BinaryOpcode.I64_AND:
+    # BinaryOpcode.I64_OR:
+    # BinaryOpcode.I64_XOR:
+    # BinaryOpcode.I64_SHL:
+    # BinaryOpcode.I64_SHR_S:
+    # BinaryOpcode.I64_SHR_U:
+    # BinaryOpcode.I64_ROTL:
+    # BinaryOpcode.I64_ROTR:
+    # BinaryOpcode.F32_ABS:
+    # BinaryOpcode.F32_NEG:
+    # BinaryOpcode.F32_CEIL:
+    # BinaryOpcode.F32_FLOOR:
+    # BinaryOpcode.F32_TRUNC:
+    # BinaryOpcode.F32_NEAREST:
+    # BinaryOpcode.F32_SQRT:
+    # BinaryOpcode.F32_ADD:
+    # BinaryOpcode.F32_SUB:
+    # BinaryOpcode.F32_MUL:
+    # BinaryOpcode.F32_DIV:
+    # BinaryOpcode.F32_MIN:
+    # BinaryOpcode.F32_MAX:
+    # BinaryOpcode.F32_COPYSIGN:
+    # BinaryOpcode.F64_ABS:
+    # BinaryOpcode.F64_NEG:
+    # BinaryOpcode.F64_CEIL:
+    # BinaryOpcode.F64_FLOOR:
+    # BinaryOpcode.F64_TRUNC:
+    # BinaryOpcode.F64_NEAREST:
+    # BinaryOpcode.F64_SQRT:
+    # BinaryOpcode.F64_ADD:
+    # BinaryOpcode.F64_SUB:
+    # BinaryOpcode.F64_MUL:
+    # BinaryOpcode.F64_DIV:
+    # BinaryOpcode.F64_MIN:
+    # BinaryOpcode.F64_MAX:
+    # BinaryOpcode.F64_COPYSIGN:
+    # BinaryOpcode.I32_WRAP_I64:
+    # BinaryOpcode.I32_TRUNC_S_F32:
+    # BinaryOpcode.I32_TRUNC_U_F32:
+    # BinaryOpcode.I32_TRUNC_S_F64:
+    # BinaryOpcode.I32_TRUNC_U_F64:
+    # BinaryOpcode.I64_EXTEND_S_I32:
+    # BinaryOpcode.I64_EXTEND_U_I32:
+    # BinaryOpcode.I64_TRUNC_S_F32:
+    # BinaryOpcode.I64_TRUNC_U_F32:
+    # BinaryOpcode.I64_TRUNC_S_F64:
+    # BinaryOpcode.I64_TRUNC_U_F64:
+    # BinaryOpcode.F32_CONVERT_S_I32:
+    # BinaryOpcode.F32_CONVERT_U_I32:
+    # BinaryOpcode.F32_CONVERT_S_I64:
+    # BinaryOpcode.F32_CONVERT_U_I64:
+    # BinaryOpcode.F32_DEMOTE_F64:
+    # BinaryOpcode.F64_CONVERT_S_I32:
+    # BinaryOpcode.F64_CONVERT_U_I32:
+    # BinaryOpcode.F64_CONVERT_S_I64:
+    # BinaryOpcode.F64_CONVERT_U_I64:
+    # BinaryOpcode.F64_PROMOTE_F32:
+    # BinaryOpcode.I32_REINTERPRET_F32:
+    # BinaryOpcode.I64_REINTERPRET_F64:
+    # BinaryOpcode.F32_REINTERPRET_I32:
+    # BinaryOpcode.F64_REINTERPRET_I64:
+    # # special case
+    # InvokeOp:
+}

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -10,6 +10,7 @@ from wasm.opcodes import (
 
 from . import control
 from . import numeric
+from . import parametric
 from . import variable
 
 if TYPE_CHECKING:
@@ -32,8 +33,8 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.RETURN: control.return_op,
     BinaryOpcode.CALL: control.call_op,
     BinaryOpcode.CALL_INDIRECT: control.call_indirect_op,
-    BinaryOpcode.DROP: control.drop_op,
-    BinaryOpcode.SELECT: control.select_op,
+    BinaryOpcode.DROP: parametric.drop_op,
+    BinaryOpcode.SELECT: parametric.select_op,
     BinaryOpcode.GET_LOCAL: variable.get_local_op,
     BinaryOpcode.SET_LOCAL: variable.set_local_op,
     BinaryOpcode.TEE_LOCAL: variable.tee_local_op,

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -8,6 +8,7 @@ from wasm.opcodes import (
     BinaryOpcode,
 )
 
+from .import numeric
 from . import control
 
 if TYPE_CHECKING:
@@ -62,32 +63,32 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     # BinaryOpcode.I64_STORE32:
     # BinaryOpcode.MEMORY_SIZE:
     # BinaryOpcode.MEMORY_GROW:
-    # BinaryOpcode.I32_CONST:
-    # BinaryOpcode.I64_CONST:
-    # BinaryOpcode.F32_CONST:
-    # BinaryOpcode.F64_CONST:
-    # BinaryOpcode.I32_EQZ:
-    # BinaryOpcode.I32_EQ:
-    # BinaryOpcode.I32_NE:
-    # BinaryOpcode.I32_LT_S:
-    # BinaryOpcode.I32_LT_U:
-    # BinaryOpcode.I32_GT_S:
-    # BinaryOpcode.I32_GT_U:
-    # BinaryOpcode.I32_LE_S:
-    # BinaryOpcode.I32_LE_U:
-    # BinaryOpcode.I32_GE_S:
-    # BinaryOpcode.I32_GE_U:
-    # BinaryOpcode.I64_EQZ:
-    # BinaryOpcode.I64_EQ:
-    # BinaryOpcode.I64_NE:
-    # BinaryOpcode.I64_LT_S:
-    # BinaryOpcode.I64_LT_U:
-    # BinaryOpcode.I64_GT_S:
-    # BinaryOpcode.I64_GT_U:
-    # BinaryOpcode.I64_LE_S:
-    # BinaryOpcode.I64_LE_U:
-    # BinaryOpcode.I64_GE_S:
-    # BinaryOpcode.I64_GE_U:
+    BinaryOpcode.I32_CONST: numeric.const_op,
+    BinaryOpcode.I64_CONST: numeric.const_op,
+    BinaryOpcode.F32_CONST: numeric.const_op,
+    BinaryOpcode.F64_CONST: numeric.const_op,
+    BinaryOpcode.I32_EQZ: numeric.ieqz_op,
+    BinaryOpcode.I32_EQ: numeric.ieq_op,
+    BinaryOpcode.I32_NE: numeric.ine_op,
+    BinaryOpcode.I32_LT_S: numeric.i32lts_op,
+    BinaryOpcode.I32_LT_U: numeric.iltu_op,
+    BinaryOpcode.I32_GT_S: numeric.i32gts_op,
+    BinaryOpcode.I32_GT_U: numeric.igtu_op,
+    BinaryOpcode.I32_LE_S: numeric.i32les_op,
+    BinaryOpcode.I32_LE_U: numeric.ileu_op,
+    BinaryOpcode.I32_GE_S: numeric.i32ges_op,
+    BinaryOpcode.I32_GE_U: numeric.igeu_op,
+    BinaryOpcode.I64_EQZ: numeric.ieqz_op,
+    BinaryOpcode.I64_EQ: numeric.ieq_op,
+    BinaryOpcode.I64_NE: numeric.ine_op,
+    BinaryOpcode.I64_LT_S: numeric.i64lts_op,
+    BinaryOpcode.I64_LT_U: numeric.iltu_op,
+    BinaryOpcode.I64_GT_S: numeric.i64gts_op,
+    BinaryOpcode.I64_GT_U: numeric.igtu_op,
+    BinaryOpcode.I64_LE_S: numeric.i64les_op,
+    BinaryOpcode.I64_LE_U: numeric.ileu_op,
+    BinaryOpcode.I64_GE_S: numeric.i64ges_op,
+    BinaryOpcode.I64_GE_U: numeric.igeu_op,
     # BinaryOpcode.F32_EQ:
     # BinaryOpcode.F32_NE:
     # BinaryOpcode.F32_LT:
@@ -100,42 +101,42 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     # BinaryOpcode.F64_GT:
     # BinaryOpcode.F64_LE:
     # BinaryOpcode.F64_GE:
-    # BinaryOpcode.I32_CLZ:
-    # BinaryOpcode.I32_CTZ:
-    # BinaryOpcode.I32_POPCNT:
-    # BinaryOpcode.I32_ADD:
-    # BinaryOpcode.I32_SUB:
-    # BinaryOpcode.I32_MUL:
-    # BinaryOpcode.I32_DIV_S:
-    # BinaryOpcode.I32_DIV_U:
-    # BinaryOpcode.I32_REM_S:
-    # BinaryOpcode.I32_REM_U:
-    # BinaryOpcode.I32_AND:
-    # BinaryOpcode.I32_OR:
-    # BinaryOpcode.I32_XOR:
-    # BinaryOpcode.I32_SHL:
-    # BinaryOpcode.I32_SHR_S:
-    # BinaryOpcode.I32_SHR_U:
-    # BinaryOpcode.I32_ROTL:
-    # BinaryOpcode.I32_ROTR:
-    # BinaryOpcode.I64_CLZ:
-    # BinaryOpcode.I64_CTZ:
-    # BinaryOpcode.I64_POPCNT:
-    # BinaryOpcode.I64_ADD:
-    # BinaryOpcode.I64_SUB:
-    # BinaryOpcode.I64_MUL:
-    # BinaryOpcode.I64_DIV_S:
-    # BinaryOpcode.I64_DIV_U:
-    # BinaryOpcode.I64_REM_S:
-    # BinaryOpcode.I64_REM_U:
-    # BinaryOpcode.I64_AND:
-    # BinaryOpcode.I64_OR:
-    # BinaryOpcode.I64_XOR:
-    # BinaryOpcode.I64_SHL:
-    # BinaryOpcode.I64_SHR_S:
-    # BinaryOpcode.I64_SHR_U:
-    # BinaryOpcode.I64_ROTL:
-    # BinaryOpcode.I64_ROTR:
+    BinaryOpcode.I32_CLZ: numeric.i32clz_op,
+    BinaryOpcode.I32_CTZ: numeric.i32ctz_op,
+    BinaryOpcode.I32_POPCNT: numeric.ipopcnt_op,
+    BinaryOpcode.I32_ADD: numeric.i32add_op,
+    BinaryOpcode.I32_SUB: numeric.i32sub_op,
+    BinaryOpcode.I32_MUL: numeric.i32mul_op,
+    BinaryOpcode.I32_DIV_S: numeric.i32divs_op,
+    BinaryOpcode.I32_DIV_U: numeric.idivu_op,
+    BinaryOpcode.I32_REM_S: numeric.i32rems_op,
+    BinaryOpcode.I32_REM_U: numeric.iremu_op,
+    BinaryOpcode.I32_AND: numeric.iand_op,
+    BinaryOpcode.I32_OR: numeric.ior_op,
+    BinaryOpcode.I32_XOR: numeric.ixor_op,
+    BinaryOpcode.I32_SHL: numeric.i32shl_op,
+    BinaryOpcode.I32_SHR_S: numeric.i32shrs_op,
+    BinaryOpcode.I32_SHR_U: numeric.i32shru_op,
+    BinaryOpcode.I32_ROTL: numeric.i32rotl_op,
+    BinaryOpcode.I32_ROTR: numeric.i32rotr_op,
+    BinaryOpcode.I64_CLZ: numeric.i64clz_op,
+    BinaryOpcode.I64_CTZ: numeric.i64ctz_op,
+    BinaryOpcode.I64_POPCNT: numeric.ipopcnt_op,
+    BinaryOpcode.I64_ADD: numeric.i64add_op,
+    BinaryOpcode.I64_SUB: numeric.i64sub_op,
+    BinaryOpcode.I64_MUL: numeric.i64mul_op,
+    BinaryOpcode.I64_DIV_S: numeric.i64divs_op,
+    BinaryOpcode.I64_DIV_U: numeric.idivu_op,
+    BinaryOpcode.I64_REM_S: numeric.i64rems_op,
+    BinaryOpcode.I64_REM_U: numeric.iremu_op,
+    BinaryOpcode.I64_AND: numeric.iand_op,
+    BinaryOpcode.I64_OR: numeric.ior_op,
+    BinaryOpcode.I64_XOR: numeric.ixor_op,
+    BinaryOpcode.I64_SHL: numeric.i64shl_op,
+    BinaryOpcode.I64_SHR_S: numeric.i64shrs_op,
+    BinaryOpcode.I64_SHR_U: numeric.i64shru_op,
+    BinaryOpcode.I64_ROTL: numeric.i64rotl_op,
+    BinaryOpcode.I64_ROTR: numeric.i64rotr_op,
     # BinaryOpcode.F32_ABS:
     # BinaryOpcode.F32_NEG:
     # BinaryOpcode.F32_CEIL:

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -9,6 +9,7 @@ from wasm.opcodes import (
 )
 
 from . import control
+from . import memory
 from . import numeric
 from . import parametric
 from . import variable
@@ -40,31 +41,31 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.TEE_LOCAL: variable.tee_local_op,
     BinaryOpcode.GET_GLOBAL: variable.get_global_op,
     BinaryOpcode.SET_GLOBAL: variable.set_global_op,
-    # BinaryOpcode.I32_LOAD:
-    # BinaryOpcode.I64_LOAD:
-    # BinaryOpcode.F32_LOAD:
-    # BinaryOpcode.F64_LOAD:
-    # BinaryOpcode.I32_LOAD8_S:
-    # BinaryOpcode.I32_LOAD8_U:
-    # BinaryOpcode.I32_LOAD16_S:
-    # BinaryOpcode.I32_LOAD16_U:
-    # BinaryOpcode.I64_LOAD8_S:
-    # BinaryOpcode.I64_LOAD8_U:
-    # BinaryOpcode.I64_LOAD16_S:
-    # BinaryOpcode.I64_LOAD16_U:
-    # BinaryOpcode.I64_LOAD32_S:
-    # BinaryOpcode.I64_LOAD32_U:
-    # BinaryOpcode.I32_STORE:
-    # BinaryOpcode.I64_STORE:
-    # BinaryOpcode.F32_STORE:
-    # BinaryOpcode.F64_STORE:
-    # BinaryOpcode.I32_STORE8:
-    # BinaryOpcode.I32_STORE16:
-    # BinaryOpcode.I64_STORE8:
-    # BinaryOpcode.I64_STORE16:
-    # BinaryOpcode.I64_STORE32:
-    # BinaryOpcode.MEMORY_SIZE:
-    # BinaryOpcode.MEMORY_GROW:
+    BinaryOpcode.I32_LOAD: memory.load_op,
+    BinaryOpcode.I64_LOAD: memory.load_op,
+    BinaryOpcode.F32_LOAD: memory.load_op,
+    BinaryOpcode.F64_LOAD: memory.load_op,
+    BinaryOpcode.I32_LOAD8_S: memory.load_op,
+    BinaryOpcode.I32_LOAD8_U: memory.load_op,
+    BinaryOpcode.I32_LOAD16_S: memory.load_op,
+    BinaryOpcode.I32_LOAD16_U: memory.load_op,
+    BinaryOpcode.I64_LOAD8_S: memory.load_op,
+    BinaryOpcode.I64_LOAD8_U: memory.load_op,
+    BinaryOpcode.I64_LOAD16_S: memory.load_op,
+    BinaryOpcode.I64_LOAD16_U: memory.load_op,
+    BinaryOpcode.I64_LOAD32_S: memory.load_op,
+    BinaryOpcode.I64_LOAD32_U: memory.load_op,
+    BinaryOpcode.I32_STORE: memory.store_op,
+    BinaryOpcode.I64_STORE: memory.store_op,
+    BinaryOpcode.F32_STORE: memory.store_op,
+    BinaryOpcode.F64_STORE: memory.store_op,
+    BinaryOpcode.I32_STORE8: memory.store_op,
+    BinaryOpcode.I32_STORE16: memory.store_op,
+    BinaryOpcode.I64_STORE8: memory.store_op,
+    BinaryOpcode.I64_STORE16: memory.store_op,
+    BinaryOpcode.I64_STORE32: memory.store_op,
+    BinaryOpcode.MEMORY_SIZE: memory.memory_size_op,
+    BinaryOpcode.MEMORY_GROW: memory.memory_grow_op,
     BinaryOpcode.I32_CONST: numeric.const_op,
     BinaryOpcode.I64_CONST: numeric.const_op,
     BinaryOpcode.F32_CONST: numeric.const_op,

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -71,8 +71,8 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.F32_CONST: numeric.const_op,
     BinaryOpcode.F64_CONST: numeric.const_op,
     BinaryOpcode.I32_EQZ: numeric.ieqz_op,
-    BinaryOpcode.I32_EQ: numeric.ieq_op,
-    BinaryOpcode.I32_NE: numeric.ine_op,
+    BinaryOpcode.I32_EQ: numeric.eq_op,
+    BinaryOpcode.I32_NE: numeric.ne_op,
     BinaryOpcode.I32_LT_S: numeric.i32lts_op,
     BinaryOpcode.I32_LT_U: numeric.iltu_op,
     BinaryOpcode.I32_GT_S: numeric.i32gts_op,
@@ -82,8 +82,8 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.I32_GE_S: numeric.i32ges_op,
     BinaryOpcode.I32_GE_U: numeric.igeu_op,
     BinaryOpcode.I64_EQZ: numeric.ieqz_op,
-    BinaryOpcode.I64_EQ: numeric.ieq_op,
-    BinaryOpcode.I64_NE: numeric.ine_op,
+    BinaryOpcode.I64_EQ: numeric.eq_op,
+    BinaryOpcode.I64_NE: numeric.ne_op,
     BinaryOpcode.I64_LT_S: numeric.i64lts_op,
     BinaryOpcode.I64_LT_U: numeric.iltu_op,
     BinaryOpcode.I64_GT_S: numeric.i64gts_op,
@@ -92,18 +92,18 @@ OPCODE_TO_LOGIC_FN: Dict[BinaryOpcode, Callable[['Configuration'], None]] = {
     BinaryOpcode.I64_LE_U: numeric.ileu_op,
     BinaryOpcode.I64_GE_S: numeric.i64ges_op,
     BinaryOpcode.I64_GE_U: numeric.igeu_op,
-    # BinaryOpcode.F32_EQ:
-    # BinaryOpcode.F32_NE:
-    # BinaryOpcode.F32_LT:
-    # BinaryOpcode.F32_GT:
-    # BinaryOpcode.F32_LE:
-    # BinaryOpcode.F32_GE:
-    # BinaryOpcode.F64_EQ:
-    # BinaryOpcode.F64_NE:
-    # BinaryOpcode.F64_LT:
-    # BinaryOpcode.F64_GT:
-    # BinaryOpcode.F64_LE:
-    # BinaryOpcode.F64_GE:
+    BinaryOpcode.F32_EQ: numeric.eq_op,
+    BinaryOpcode.F32_NE: numeric.ne_op,
+    BinaryOpcode.F32_LT: numeric.flt_op,
+    BinaryOpcode.F32_GT: numeric.fgt_op,
+    BinaryOpcode.F32_LE: numeric.fle_op,
+    BinaryOpcode.F32_GE: numeric.fge_op,
+    BinaryOpcode.F64_EQ: numeric.eq_op,
+    BinaryOpcode.F64_NE: numeric.ne_op,
+    BinaryOpcode.F64_LT: numeric.flt_op,
+    BinaryOpcode.F64_GT: numeric.fgt_op,
+    BinaryOpcode.F64_LE: numeric.fle_op,
+    BinaryOpcode.F64_GE: numeric.fge_op,
     BinaryOpcode.I32_CLZ: numeric.i32clz_op,
     BinaryOpcode.I32_CTZ: numeric.i32ctz_op,
     BinaryOpcode.I32_POPCNT: numeric.ipopcnt_op,

--- a/wasm/logic/control.py
+++ b/wasm/logic/control.py
@@ -1,0 +1,286 @@
+import logging
+from typing import (
+    Tuple,
+    cast,
+)
+
+from wasm.datatypes import (
+    FunctionAddress,
+    FunctionInstance,
+    HostFunction,
+    LabelIdx,
+)
+from wasm.exceptions import (
+    Exhaustion,
+    Trap,
+)
+from wasm.execution import (
+    Configuration,
+    Frame,
+    Label,
+)
+from wasm.instructions import (
+    Block,
+    Br,
+    BrIf,
+    BrTable,
+    Call,
+    CallIndirect,
+    If,
+    Loop,
+)
+from wasm.typing import (
+    TValue,
+)
+
+logger = logging.getLogger('wasm.logic.control')
+
+
+def unreachable_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+    raise Trap("TRAP")
+
+
+def nop_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+
+def block_op(config: Configuration) -> None:
+    block = cast(Block, config.instructions.current)
+
+    logger.debug("%s()", block.opcode.text)
+
+    label = Label(
+        arity=len(block.result_type),
+        instructions=block.instructions,
+        is_loop=False,
+    )
+    config.push_label(label)
+
+
+def loop_op(config: Configuration) -> None:
+    instruction = cast(Loop, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    label = Label(
+        arity=0,
+        instructions=instruction.instructions,
+        is_loop=True,
+    )
+    config.push_label(label)
+
+
+def if_op(config: Configuration) -> None:
+    instruction = cast(If, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    value = config.pop_operand()
+    arity = len(instruction.result_type)
+
+    if value:
+        label = Label(
+            arity=arity,
+            instructions=instruction.instructions,
+            is_loop=False,
+        )
+    else:
+        label = Label(
+            arity=arity,
+            instructions=instruction.else_instructions,
+            is_loop=False,
+        )
+
+    config.push_label(label)
+
+
+def _exit_block(config: Configuration) -> None:
+    label = config.pop_label()
+    config.extend_operands(label.operand_stack)
+
+
+def _return_from_function(config: Configuration) -> None:
+    valn = tuple(config.pop_operand() for _ in range(config.frame.arity))
+    config.pop_frame()
+
+    if config.has_active_frame:
+        config.extend_operands(valn)
+    else:
+        config.extend_results(valn)
+
+
+def else_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    _exit_block(config)
+
+
+def end_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    if config.has_active_label:
+        _exit_block(config)
+    elif config.has_active_frame:
+        _return_from_function(config)
+    else:
+        raise Exception("Invariant?")
+
+
+def _br(config: Configuration, label_idx: LabelIdx) -> None:
+    label = config.get_by_label_idx(label_idx)
+    # take any return values off of the stack before poping labels
+    valn = tuple(config.pop_operand() for _ in range(label.arity))
+
+    if label.is_loop:
+        # For loops we keep the label which represents the loop on the stack
+        # since the continuation of a loop is beginning back at the beginning
+        # of the loop itself.
+        for _ in range(label_idx):
+            config.pop_label()
+        config.instructions.seek(0)
+    else:
+        for _ in range(label_idx + 1):
+            config.pop_label()
+
+    # put return values back on the stack.
+    config.extend_operands(valn)
+
+
+def br_op(config: Configuration) -> None:
+    instruction = cast(Br, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    _br(config, instruction.label_idx)
+
+
+def br_if_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    value = config.pop_operand()
+
+    if value:
+        instruction = cast(BrIf, config.instructions.current)
+        _br(config, instruction.label_idx)
+
+
+def br_table_op(config: Configuration) -> None:
+    instruction = cast(BrTable, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    label_indices = instruction.label_indices
+    default_label_idx = instruction.default_idx
+
+    idx = config.pop_operand()
+
+    if idx < len(label_indices):
+        label_idx = label_indices[int(idx)]
+        _br(config, label_idx)
+    else:
+        _br(config, default_label_idx)
+
+
+def return_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    _return_from_function(config)
+
+
+def _setup_call(config: Configuration, function_address: FunctionAddress) -> None:
+    function = config.store.funcs[function_address]
+    function_args = tuple(reversed([
+        config.pop_operand()
+        for _ in range(len(function.type.params))
+    ]))
+    _setup_function_invocation(config, function_address, function_args)
+
+
+def _setup_function_invocation(config: Configuration,
+                               function_address: FunctionAddress,
+                               function_args: Tuple[TValue, ...]) -> None:
+    if config.frame_stack_size > 1024:
+        # TODO: this is not part of spec, but this is required to pass tests.
+        # Tests pass with limit 10000, maybe more
+        raise Exhaustion("Function length greater than 1024")
+
+    function = config.store.funcs[function_address]
+
+    if len(function_args) != len(function.type.params):
+        raise TypeError(
+            f"Wrong number of arguments. Expected {len(function.type.params)} "
+            f"Got {len(function_args)}"
+        )
+
+    if isinstance(function, FunctionInstance):
+        locals = [valtype.zero_value for valtype in function.code.locals]
+        frame = Frame(
+            module=function.module,
+            locals=list(function_args) + locals,
+            # TODO: do we need this wrapping anymore?
+            instructions=Block.wrap_with_end(function.type.results, function.code.body),
+            arity=len(function.type.results),
+        )
+        config.push_frame(frame)
+    elif isinstance(function, HostFunction):
+        ret = function.hostcode(config, function_args)
+        if len(ret) > 1:
+            raise Exception("Invariant")
+        elif ret:
+            config.push_operand(ret[0])
+    else:
+        raise Exception("Invariant: unreachable code path")
+
+
+def call_op(config: Configuration) -> None:
+    instruction = cast(Call, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    function_address = config.frame.module.func_addrs[instruction.function_idx]
+    _setup_call(config, function_address)
+
+
+def call_indirect_op(config: Configuration) -> None:
+    instruction = cast(CallIndirect, config.instructions.current)
+
+    logger.debug("%s()", instruction.opcode.text)
+
+    table_address = config.frame.module.table_addrs[0]
+    table = config.store.tables[table_address]
+    function_type = config.frame.module.types[instruction.type_idx]
+
+    element_idx = config.pop_u32()
+
+    if len(table.elem) <= element_idx:
+        raise Trap("Element index out of table range: {element_idx} > {len(table.elem)}")
+
+    function_address = table.elem[element_idx]
+
+    if function_address is None:
+        raise Trap("Table element at index {element_idx} is empty")
+
+    function = config.store.funcs[int(function_address)]
+
+    if function.type != function_type:
+        raise Trap("Function type mismatch.  Expected {function_type}.  Got {function.type}")
+
+    _setup_call(config, function_address)
+
+
+def drop_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    config.pop_operand()
+
+
+def select_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    a, b, c = config.pop3_operands()
+
+    if a:
+        config.push_operand(c)
+    else:
+        config.push_operand(b)

--- a/wasm/logic/control.py
+++ b/wasm/logic/control.py
@@ -267,20 +267,3 @@ def call_indirect_op(config: Configuration) -> None:
         raise Trap("Function type mismatch.  Expected {function_type}.  Got {function.type}")
 
     _setup_call(config, function_address)
-
-
-def drop_op(config: Configuration) -> None:
-    logger.debug("%s()", config.instructions.current.opcode.text)
-
-    config.pop_operand()
-
-
-def select_op(config: Configuration) -> None:
-    logger.debug("%s()", config.instructions.current.opcode.text)
-
-    a, b, c = config.pop3_operands()
-
-    if a:
-        config.push_operand(c)
-    else:
-        config.push_operand(b)

--- a/wasm/logic/memory.py
+++ b/wasm/logic/memory.py
@@ -1,0 +1,148 @@
+import logging
+import struct
+from typing import (
+    Dict,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    s32_to_u32,
+    s64_to_u64,
+)
+from wasm.datatypes import (
+    BitSize,
+    ValType,
+)
+from wasm.exceptions import (
+    ValidationError,
+)
+from wasm.execution import (
+    Configuration,
+)
+from wasm.instructions import (
+    MemoryOp,
+)
+from wasm.typing import (
+    SInt32,
+    SInt64,
+    UInt32,
+    UInt64,
+)
+
+logger = logging.getLogger('wasm.logic.memory')
+
+
+TInteger = Union[UInt32, UInt64, SInt32, SInt64]
+
+PARSER_LOOKUP: Dict[Tuple[BitSize, Optional[bool]], str] = {
+    (BitSize.b8, True): '<b',
+    (BitSize.b8, False): '<B',
+    (BitSize.b8, None): '<B',
+    (BitSize.b16, True): '<h',
+    (BitSize.b16, False): '<H',
+    (BitSize.b16, None): '<H',
+    (BitSize.b32, True): '<i',
+    (BitSize.b32, False): '<I',
+    (BitSize.b32, None): '<I',
+    (BitSize.b64, True): '<q',
+    (BitSize.b64, False): '<Q',
+    (BitSize.b64, None): '<Q',
+}
+
+
+def load_op(config: Configuration) -> None:
+    instruction = cast(MemoryOp, config.instructions.current)
+    logger.debug("%s()", instruction.opcode.text)
+
+    memarg = instruction.memarg
+
+    memory_address = config.frame.module.memory_addrs[0]
+    mem = config.store.mems[memory_address]
+
+    base_offset = config.pop_u32()
+    memory_location = UInt32(base_offset + memarg.offset)
+
+    value_bit_width = instruction.memory_bit_size.value
+    value_byte_width = value_bit_width // 8
+
+    raw_bytes = mem.read(memory_location, value_byte_width)
+    fmt = PARSER_LOOKUP[(instruction.memory_bit_size, instruction.signed)]
+
+    value = struct.unpack(fmt, raw_bytes)[0]
+
+    if not instruction.signed:
+        config.push_operand(value)
+    elif instruction.valtype is ValType.i32:
+        config.push_operand(s32_to_u32(value))
+    elif instruction.valtype is ValType.i64:
+        config.push_operand(s64_to_u64(value))
+    else:
+        raise Exception("Invariant")
+
+
+ENCODER_LOOKUP: Dict[BitSize, str] = {
+    BitSize.b8: '<B',
+    BitSize.b16: '<H',
+    BitSize.b32: '<I',
+    BitSize.b64: '<Q',
+}
+
+
+def store_op(config: Configuration) -> None:
+    instruction = cast(MemoryOp, config.instructions.current)
+    logger.debug("%s()", instruction.opcode.text)
+
+    memarg = instruction.memarg
+
+    memory_address = config.frame.module.memory_addrs[0]
+    mem = config.store.mems[memory_address]
+
+    value = config.pop_operand()
+
+    base_offset = config.pop_u32()
+    memory_location = UInt32(base_offset + memarg.offset)
+
+    if instruction.valtype.is_integer_type:
+        fmt = ENCODER_LOOKUP[instruction.memory_bit_size]
+        wrapped_value = value % (2 ** instruction.memory_bit_size.value)
+        encoded_value = struct.pack(fmt, wrapped_value)
+    elif instruction.valtype is ValType.f32:
+        encoded_value = struct.pack('<f', value)
+    elif instruction.valtype is ValType.f64:
+        encoded_value = struct.pack('<d', value)
+    else:
+        raise Exception("Invariant")
+
+    assert len(encoded_value) == instruction.memory_bit_size.value // 8
+    mem.write(memory_location, encoded_value)
+
+
+def memory_size_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    memory_address = config.frame.module.memory_addrs[0]
+    mem = config.store.mems[memory_address]
+    size = UInt32(len(mem.data) // constants.PAGE_SIZE_64K)
+    config.push_operand(size)
+
+
+def memory_grow_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    memory_address = config.frame.module.memory_addrs[0]
+    mem = config.store.mems[memory_address]
+    current_num_pages = mem.num_pages
+    num_pages = config.pop_u32()
+
+    try:
+        mem.grow(num_pages)
+    except ValidationError:
+        config.push_operand(constants.INT32_NEGATIVE_ONE)
+    else:
+        config.push_operand(current_num_pages)

--- a/wasm/logic/numeric.py
+++ b/wasm/logic/numeric.py
@@ -1,0 +1,564 @@
+import decimal
+import logging
+from typing import (
+    Union,
+    cast,
+)
+
+from wasm import (
+    constants,
+)
+from wasm._utils.numeric import (
+    s32_to_u32,
+    s64_to_u64,
+    u32_to_s32,
+    u64_to_s64,
+)
+from wasm.exceptions import (
+    Trap,
+)
+from wasm.execution import (
+    Configuration,
+)
+from wasm.instructions import (
+    F32Const,
+    F64Const,
+    I32Const,
+    I64Const,
+)
+from wasm.typing import (
+    SInt32,
+    SInt64,
+    UInt32,
+    UInt64,
+)
+
+logger = logging.getLogger('wasm.logic.numeric')
+
+TConst = Union[F32Const, F64Const, I32Const, I64Const]
+
+
+def const_op(config: Configuration) -> None:
+    instruction = cast(TConst, config.instructions.current)
+    logger.debug("%s(%s)", instruction.opcode.text, instruction)
+
+    config.push_operand(instruction.value)
+
+
+def ieqz_op(config: Configuration) -> None:
+    value = config.pop_operand()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    if value == 0:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+#
+# Integer equality comparisons
+#
+def ieq_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a == b:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def ine_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a == b:
+        config.push_operand(UInt32(0))
+    else:
+        config.push_operand(UInt32(1))
+
+
+#
+# Unsigned integer comparisons
+#
+def iltu_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a < b:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def ileu_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a <= b:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def igtu_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a > b:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def igeu_op(config: Configuration) -> None:
+    b, a = config.pop2_operands()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if a >= b:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+#
+# 32-bit Signed integer comparisons
+#
+def i32lts_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s < b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i32les_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s <= b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i32gts_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s > b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i32ges_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s >= b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+#
+# 64-bit Signed integer comparisons
+#
+def i64lts_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s < b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i64les_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s <= b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i64gts_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s > b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+def i64ges_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if a_s >= b_s:
+        config.push_operand(UInt32(1))
+    else:
+        config.push_operand(UInt32(0))
+
+
+#
+# Integer addition
+#
+def i32add_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32((a + b) % constants.UINT32_CEIL))
+
+
+def i64add_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64((a + b) % constants.UINT64_CEIL))
+
+
+def i32sub_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32((a - b) % constants.UINT32_CEIL))
+
+
+def i64sub_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64((a - b) % constants.UINT64_CEIL))
+
+
+#
+# Integer multiplication
+#
+def i32mul_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32((a * b) % constants.UINT32_CEIL))
+
+
+def i64mul_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64((a * b) % constants.UINT64_CEIL))
+
+
+#
+# Integer division
+#
+def idivu_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+    config.push_operand(UInt32(a // b))
+
+
+def i32divs_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+
+    raw_result = a_s / b_s
+    if raw_result == constants.SINT32_CEIL:
+        raise Trap('UNDEFINED')
+    config.push_operand(s32_to_u32(SInt32(int(raw_result))))
+
+
+def i64divs_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a_s, b_s)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+
+    # decimal wrapping needed to ensure float precision doesn't cause rounding
+    # error.  21 *appears* to be the right precision, since 2**64 has 20 digits
+    # and we want one more to handle correct rounding.
+    with decimal.localcontext() as ctx:
+        ctx.prec = 21
+        raw_result = decimal.Decimal(a_s) / b_s
+    if raw_result == constants.SINT64_CEIL:
+        raise Trap('UNDEFINED')
+    config.push_operand(s64_to_u64(SInt64(int(raw_result))))
+
+
+#
+# Count leading zeros
+#
+def i32clz_op(config: Configuration) -> None:
+    value = config.pop_u32()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    config.push_operand(UInt32(32 - value.bit_length()))
+
+
+def i64clz_op(config: Configuration) -> None:
+    value = config.pop_u64()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    config.push_operand(UInt64(64 - value.bit_length()))
+
+
+POWERS_OF_TWO = tuple(
+    2**i
+    for i in range(64)
+)
+
+
+#
+# Count trailing zeros
+#
+def i32ctz_op(config: Configuration) -> None:
+    value = config.pop_u32()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    if value == 0:
+        config.push_operand(UInt32(32))
+    else:
+        for idx, power_of_two in enumerate(POWERS_OF_TWO[:32]):
+            if value & power_of_two:
+                config.push_operand(UInt32(idx))
+                break
+        else:
+            raise Exception("Invariant")
+
+
+def i64ctz_op(config: Configuration) -> None:
+    value = config.pop_u64()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    if value == 0:
+        config.push_operand(UInt64(64))
+    else:
+        for idx, power_of_two in enumerate(POWERS_OF_TWO):
+            if value & power_of_two:
+                config.push_operand(UInt64(idx))
+                break
+        else:
+            raise Exception("Invariant")
+
+
+#
+# Count non-zero bits
+#
+def ipopcnt_op(config: Configuration) -> None:
+    value = config.pop_operand()
+    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+
+    if value == 0:
+        config.push_operand(UInt32(0))
+    else:
+        config.push_operand(UInt32(bin(int(value)).count('1')))
+
+
+#
+# Remainders
+#
+def iremu_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+
+    config.push_operand(UInt32(a % b))
+
+
+def i32rems_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+
+    b_s = u32_to_s32(b)
+    a_s = u32_to_s32(a)
+
+    raw_result = abs(a_s) % abs(b_s)
+    result = -1 * raw_result if a_s < 0 else raw_result
+
+    config.push_operand(s32_to_u32(SInt32(int(result))))
+
+
+def i64rems_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    if b == 0:
+        raise Trap('DIVISION BY ZERO')
+
+    b_s = u64_to_s64(b)
+    a_s = u64_to_s64(a)
+
+    raw_result = abs(a_s) % abs(b_s)
+    result = -1 * raw_result if a_s < 0 else raw_result
+
+    config.push_operand(s64_to_u64(SInt64(int(result))))
+
+
+#
+# Logical and/or/xor
+#
+def iand_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64(a & b))
+
+
+def ior_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64(a | b))
+
+
+def ixor_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64(a ^ b))
+
+
+#
+# Bitwise shifting
+#
+def i32shl_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32((a << (b % 32)) % constants.UINT32_CEIL))
+
+
+def i64shl_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64((a << (b % 64)) % constants.UINT64_CEIL))
+
+
+def i32shru_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32(a >> (b % 32)))
+
+
+def i64shru_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64(a >> (b % 64)))
+
+
+def i32shrs_op(config: Configuration) -> None:
+    b, a = config.pop2_u32()
+
+    a_s = u32_to_s32(a)
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt32(
+        s32_to_u32(SInt32(a_s >> (b % 32)))
+    ))
+
+
+def i64shrs_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    a_s = u64_to_s64(a)
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    config.push_operand(UInt64(
+        s64_to_u64(SInt64(a_s >> (b % 64)))
+    ))
+
+
+#
+# Bitwise rotation
+#
+def i32rotl_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    shift_size = b % 32
+    upper = a << shift_size
+    lower = a >> (32 - shift_size)
+
+    config.push_operand(UInt32((upper | lower) % constants.UINT32_CEIL))
+
+
+def i64rotl_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    shift_size = b % 64
+    upper = a << shift_size
+    lower = a >> (64 - shift_size)
+
+    config.push_operand(UInt64((upper | lower) % constants.UINT64_CEIL))
+
+
+def i32rotr_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    shift_size = b % 32
+    lower = a >> shift_size
+    upper = a << (32 - shift_size)
+
+    config.push_operand(UInt32((upper | lower) % constants.UINT32_CEIL))
+
+
+def i64rotr_op(config: Configuration) -> None:
+    b, a = config.pop2_u64()
+
+    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+
+    shift_size = b % 64
+    lower = a >> shift_size
+    upper = a << (64 - shift_size)
+
+    config.push_operand(UInt64((upper | lower) % constants.UINT64_CEIL))

--- a/wasm/logic/numeric.py
+++ b/wasm/logic/numeric.py
@@ -1,5 +1,6 @@
 import decimal
 import logging
+import math
 from typing import (
     Union,
     cast,
@@ -25,6 +26,7 @@ from wasm.instructions import (
     F64Const,
     I32Const,
     I64Const,
+    RelOp,
 )
 from wasm.typing import (
     SInt32,
@@ -56,9 +58,9 @@ def ieqz_op(config: Configuration) -> None:
 
 
 #
-# Integer equality comparisons
+# Equality equality comparisons
 #
-def ieq_op(config: Configuration) -> None:
+def eq_op(config: Configuration) -> None:
     b, a = config.pop2_operands()
     logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
 
@@ -68,7 +70,7 @@ def ieq_op(config: Configuration) -> None:
         config.push_operand(UInt32(0))
 
 
-def ine_op(config: Configuration) -> None:
+def ne_op(config: Configuration) -> None:
     b, a = config.pop2_operands()
     logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
 
@@ -562,3 +564,74 @@ def i64rotr_op(config: Configuration) -> None:
     upper = a << (64 - shift_size)
 
     config.push_operand(UInt64((upper | lower) % constants.UINT64_CEIL))
+
+
+#
+# Float comparisons
+#
+def flt_op(config):
+    instruction = cast(RelOp, config.instructions.current)
+
+    b, a = config.pop2_f64()
+
+    logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
+
+    if math.isnan(a) or math.isnan(b):
+        config.push_operand(0)
+    elif math.isinf(a):
+        config.push_operand(UInt32(a == -math.inf))
+    elif math.isinf(b):
+        config.push_operand(UInt32(b == math.inf))
+    else:
+        config.push_operand(UInt32(a < b))
+
+
+def fgt_op(config):
+    instruction = cast(RelOp, config.instructions.current)
+
+    b, a = config.pop2_f64()
+
+    logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
+
+    if math.isnan(a) or math.isnan(b):
+        config.push_operand(0)
+    elif math.isinf(a):
+        config.push_operand(UInt32(a == math.inf))
+    elif math.isinf(b):
+        config.push_operand(UInt32(b == -math.inf))
+    else:
+        config.push_operand(UInt32(a > b))
+
+
+def fle_op(config):
+    instruction = cast(RelOp, config.instructions.current)
+
+    b, a = config.pop2_f64()
+
+    logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
+
+    if math.isnan(a) or math.isnan(b):
+        config.push_operand(0)
+    elif math.isinf(a):
+        config.push_operand(UInt32(a == -math.inf))
+    elif math.isinf(b):
+        config.push_operand(UInt32(b == math.inf))
+    else:
+        config.push_operand(UInt32(a <= b))
+
+
+def fge_op(config):
+    instruction = cast(RelOp, config.instructions.current)
+
+    b, a = config.pop2_f64()
+
+    logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
+
+    if math.isnan(a) or math.isnan(b):
+        config.push_operand(0)
+    elif math.isinf(a):
+        config.push_operand(UInt32(a == math.inf))
+    elif math.isinf(b):
+        config.push_operand(UInt32(b == -math.inf))
+    else:
+        config.push_operand(UInt32(a >= b))

--- a/wasm/logic/parametric.py
+++ b/wasm/logic/parametric.py
@@ -4,7 +4,7 @@ from wasm.execution import (
     Configuration,
 )
 
-logger = logging.getLogger('wasm.logic.control')
+logger = logging.getLogger('wasm.logic.parametric')
 
 
 def drop_op(config: Configuration) -> None:

--- a/wasm/logic/parametric.py
+++ b/wasm/logic/parametric.py
@@ -1,0 +1,24 @@
+import logging
+
+from wasm.execution import (
+    Configuration,
+)
+
+logger = logging.getLogger('wasm.logic.control')
+
+
+def drop_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    config.pop_operand()
+
+
+def select_op(config: Configuration) -> None:
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    a, b, c = config.pop3_operands()
+
+    if a:
+        config.push_operand(c)
+    else:
+        config.push_operand(b)

--- a/wasm/logic/variable.py
+++ b/wasm/logic/variable.py
@@ -1,0 +1,64 @@
+import logging
+from typing import (
+    cast,
+)
+
+from wasm.datatypes import (
+    GlobalInstance,
+    Mutability,
+)
+from wasm.execution import (
+    Configuration,
+)
+from wasm.instructions import (
+    GlobalOp,
+    LocalOp,
+)
+
+logger = logging.getLogger('wasm.logic.variable')
+
+
+def set_local_op(config: Configuration) -> None:
+    instruction = cast(LocalOp, config.instructions.current)
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    value = config.pop_operand()
+    config.frame.locals[instruction.local_idx] = value
+
+
+def get_local_op(config: Configuration) -> None:
+    instruction = cast(LocalOp, config.instructions.current)
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    value = config.frame.locals[instruction.local_idx]
+    config.push_operand(value)
+
+
+def tee_local_op(config: Configuration) -> None:
+    instruction = cast(LocalOp, config.instructions.current)
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    value = config.pop_operand()
+    config.frame.locals[instruction.local_idx] = value
+    config.push_operand(value)
+
+
+def get_global_op(config: Configuration) -> None:
+    instruction = cast(GlobalOp, config.instructions.current)
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    global_address = config.frame.module.global_addrs[instruction.global_idx]
+    global_ = config.store.globals[global_address]
+    config.push_operand(global_.value)
+
+
+def set_global_op(config: Configuration) -> None:
+    instruction = cast(GlobalOp, config.instructions.current)
+    logger.debug("%s()", config.instructions.current.opcode.text)
+
+    global_address = config.frame.module.global_addrs[instruction.global_idx]
+    global_ = config.store.globals[global_address]
+    if global_.mut is not Mutability.var:
+        raise Exception("Attempt to set immutable global")
+    value = config.pop_operand()
+    config.store.globals[global_address] = GlobalInstance(global_.valtype, value, global_.mut)

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -13,9 +13,7 @@ from wasm import (
     constants,
 )
 from wasm.datatypes import (
-    GlobalInstance,
     MemoryInstance,
-    Mutability,
     ValType,
 )
 from wasm.exceptions import (
@@ -31,8 +29,6 @@ from wasm.instructions import (
     Convert,
     Demote,
     Extend,
-    GlobalOp,
-    LocalOp,
     MemoryOp,
     Promote,
     Reinterpret,
@@ -963,54 +959,6 @@ def spec_t2cvtopt1(config: Configuration) -> None:
 # 4.4.3 VARIABLE INSTRUCTIONS
 
 
-def spec_get_local(config: Configuration) -> None:
-    logger.debug("spec_get_local()")
-
-    instruction = cast(LocalOp, config.instructions.current)
-    val = config.frame.locals[instruction.local_idx]
-    config.push_operand(val)
-
-
-def spec_set_local(config: Configuration) -> None:
-    logger.debug("spec_set_local()")
-
-    instruction = cast(LocalOp, config.instructions.current)
-    val = config.pop_operand()
-    config.frame.locals[instruction.local_idx] = val
-
-
-def spec_tee_local(config: Configuration) -> None:
-    logger.debug("spec_tee_local()")
-
-    val = config.pop_operand()
-    config.push_operand(val)
-    config.push_operand(val)
-    spec_set_local(config)
-
-
-def spec_get_global(config: Configuration) -> None:
-    logger.debug("spec_get_global()")
-
-    S = config.store
-    instruction = cast(GlobalOp, config.instructions.current)
-    a = config.frame.module.global_addrs[instruction.global_idx]
-    glob = S.globals[a]
-    config.push_operand(glob.value)
-
-
-def spec_set_global(config):
-    logger.debug("spec_set_global()")
-
-    S = config.store
-    instruction = cast(GlobalOp, config.instructions.current)
-    a = config.frame.module.global_addrs[instruction.global_idx]
-    glob = S.globals[a]
-    if glob.mut is not Mutability.var:
-        raise Exception("Attempt to set immutable global")
-    val = config.pop_operand()
-    S.globals[a] = GlobalInstance(glob.valtype, val, glob.mut)
-
-
 # 4.4.4 MEMORY INSTRUCTIONS
 
 # this is for both t.load and t.loadN_sx
@@ -1176,11 +1124,11 @@ opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
     # BinaryOpcode.CALL_INDIRECT: (spec_call_indirect,),  # typeidx 0x00
     # BinaryOpcode.DROP: (spec_drop,),
     # BinaryOpcode.SELECT: (spec_select,),
-    BinaryOpcode.GET_LOCAL: (spec_get_local,),  # localidx
-    BinaryOpcode.SET_LOCAL: (spec_set_local,),  # localidx
-    BinaryOpcode.TEE_LOCAL: (spec_tee_local,),  # localidx
-    BinaryOpcode.GET_GLOBAL: (spec_get_global,),  # globalidx
-    BinaryOpcode.SET_GLOBAL: (spec_set_global,),  # globalidx
+    # BinaryOpcode.GET_LOCAL: (spec_get_local,),  # localidx
+    # BinaryOpcode.SET_LOCAL: (spec_set_local,),  # localidx
+    # BinaryOpcode.TEE_LOCAL: (spec_tee_local,),  # localidx
+    # BinaryOpcode.GET_GLOBAL: (spec_get_global,),  # globalidx
+    # BinaryOpcode.SET_GLOBAL: (spec_set_global,),  # globalidx
     BinaryOpcode.I32_LOAD: (spec_tload,),  # memarg
     BinaryOpcode.I64_LOAD: (spec_tload,),  # memarg
     BinaryOpcode.F32_LOAD: (spec_tload,),  # memarg

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -636,124 +636,6 @@ def spec_fcopysignN(N, z1, z2):
         return z1
 
 
-def spec_feqN(N, z1, z2):
-    logger.debug("spec_feqN(%s, %s, %s)", N, z1, z2)
-
-    if z1 == z2:
-        return 1
-    else:
-        return 0
-
-
-def spec_fneN(N, z1, z2):
-    logger.debug("spec_fneN(%s, %s, %s)", N, z1, z2)
-
-    if z1 != z2:
-        return 1
-    else:
-        return 0
-
-
-def spec_fltN(N, z1, z2):
-    logger.debug("spec_fltN(%s, %s, %s)", N, z1, z2)
-
-    if math.isnan(z1):
-        return 0
-    elif math.isnan(z2):
-        return 0
-    elif spec_bitsfN(N, z1) == spec_bitsfN(N, z2):
-        return 0
-    elif z1 == math.inf:
-        return 0
-    elif z1 == -math.inf:
-        return 1
-    elif z2 == math.inf:
-        return 1
-    elif z2 == -math.inf:
-        return 0
-    elif z1 == z2 == 0:
-        return 0
-    elif z1 < z2:
-        return 1
-    else:
-        return 0
-
-
-def spec_fgtN(N, z1, z2):
-    logger.debug("spec_fgtN(%s, %s, %s)", N, z1, z2)
-
-    if math.isnan(z1):
-        return 0
-    elif math.isnan(z2):
-        return 0
-    elif spec_bitsfN(N, z1) == spec_bitsfN(N, z2):
-        return 0
-    elif z1 == math.inf:
-        return 1
-    elif z1 == -math.inf:
-        return 0
-    elif z2 == math.inf:
-        return 0
-    elif z2 == -math.inf:
-        return 1
-    elif z1 == z2 == 0:
-        return 0
-    elif z1 > z2:
-        return 1
-    else:
-        return 0
-
-
-def spec_fleN(N, z1, z2):
-    logger.debug("spec_fleN(%s, %s, %s)", N, z1, z2)
-
-    if math.isnan(z1):
-        return 0
-    elif math.isnan(z2):
-        return 0
-    elif spec_bitsfN(N, z1) == spec_bitsfN(N, z2):
-        return 1
-    elif z1 == math.inf:
-        return 0
-    elif z1 == -math.inf:
-        return 1
-    elif z2 == math.inf:
-        return 1
-    elif z2 == -math.inf:
-        return 0
-    elif z1 == z2 == 0:
-        return 1
-    elif z1 <= z2:
-        return 1
-    else:
-        return 0
-
-
-def spec_fgeN(N, z1, z2):
-    logger.debug("spec_fgeN(%s, %s, %s)", N, z1, z2)
-
-    if math.isnan(z1):
-        return 0
-    elif math.isnan(z2):
-        return 0
-    elif spec_bitsfN(N, z1) == spec_bitsfN(N, z2):
-        return 1
-    elif z1 == math.inf:
-        return 1
-    elif z1 == -math.inf:
-        return 0
-    elif z2 == math.inf:
-        return 0
-    elif z2 == -math.inf:
-        return 1
-    elif z1 == z2 == 0:
-        return 1
-    elif z1 >= z2:
-        return 1
-    else:
-        return 0
-
-
 # 4.3.4 CONVERSIONS
 
 
@@ -1039,18 +921,18 @@ opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
     # BinaryOpcode.I64_LE_U: (spec_trelop, spec_ile_uN),
     # BinaryOpcode.I64_GE_S: (spec_trelop, spec_ige_sN),
     # BinaryOpcode.I64_GE_U: (spec_trelop, spec_ige_uN),
-    BinaryOpcode.F32_EQ: (spec_trelop, spec_feqN),
-    BinaryOpcode.F32_NE: (spec_trelop, spec_fneN),
-    BinaryOpcode.F32_LT: (spec_trelop, spec_fltN),
-    BinaryOpcode.F32_GT: (spec_trelop, spec_fgtN),
-    BinaryOpcode.F32_LE: (spec_trelop, spec_fleN),
-    BinaryOpcode.F32_GE: (spec_trelop, spec_fgeN),
-    BinaryOpcode.F64_EQ: (spec_trelop, spec_feqN),
-    BinaryOpcode.F64_NE: (spec_trelop, spec_fneN),
-    BinaryOpcode.F64_LT: (spec_trelop, spec_fltN),
-    BinaryOpcode.F64_GT: (spec_trelop, spec_fgtN),
-    BinaryOpcode.F64_LE: (spec_trelop, spec_fleN),
-    BinaryOpcode.F64_GE: (spec_trelop, spec_fgeN),
+    # BinaryOpcode.F32_EQ: (spec_trelop, spec_feqN),
+    # BinaryOpcode.F32_NE: (spec_trelop, spec_fneN),
+    # BinaryOpcode.F32_LT: (spec_trelop, spec_fltN),
+    # BinaryOpcode.F32_GT: (spec_trelop, spec_fgtN),
+    # BinaryOpcode.F32_LE: (spec_trelop, spec_fleN),
+    # BinaryOpcode.F32_GE: (spec_trelop, spec_fgeN),
+    # BinaryOpcode.F64_EQ: (spec_trelop, spec_feqN),
+    # BinaryOpcode.F64_NE: (spec_trelop, spec_fneN),
+    # BinaryOpcode.F64_LT: (spec_trelop, spec_fltN),
+    # BinaryOpcode.F64_GT: (spec_trelop, spec_fgtN),
+    # BinaryOpcode.F64_LE: (spec_trelop, spec_fleN),
+    # BinaryOpcode.F64_GE: (spec_trelop, spec_fgeN),
     # BinaryOpcode.I32_CLZ: (spec_tunop, spec_iclzN),
     # BinaryOpcode.I32_CTZ: (spec_tunop, spec_ictzN),
     # BinaryOpcode.I32_POPCNT: (spec_tunop, spec_ipopcntN),

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -1,14 +1,10 @@
-import io
 import logging
 import math
 import struct
 from typing import (
     Callable,
     Dict,
-    List,
-    NamedTuple,
     Tuple,
-    Type,
     Union,
     cast,
 )
@@ -17,49 +13,26 @@ from wasm import (
     constants,
 )
 from wasm.datatypes import (
-    FunctionAddress,
-    FunctionInstance,
     GlobalInstance,
-    HostFunction,
-    LabelIdx,
     MemoryInstance,
-    ModuleInstance,
     Mutability,
-    Store,
     ValType,
 )
 from wasm.exceptions import (
-    Exhaustion,
-    InvalidModule,
-    MalformedModule,
-    ParseError,
     Trap,
     ValidationError,
 )
 from wasm.execution import (
     Configuration,
-    Frame,
-    InstructionSequence,
-    Label,
-    OperandStack,
 )
 from wasm.instructions import (
     BaseInstruction,
     BinOp,
-    Block,
-    Br,
-    BrIf,
-    BrTable,
-    Call,
-    CallIndirect,
     Convert,
     Demote,
-    End,
     Extend,
     GlobalOp,
-    If,
     LocalOp,
-    Loop,
     MemoryOp,
     Promote,
     Reinterpret,
@@ -71,16 +44,8 @@ from wasm.instructions import (
 from wasm.opcodes import (
     BinaryOpcode,
 )
-from wasm.parsers import (
-    parse_module,
-)
 from wasm.typing import (
-    Float32,
-    TValue,
     UInt32,
-)
-from wasm.validation import (
-    validate_module as _validate_module,
 )
 
 logger = logging.getLogger('wasm.spec')
@@ -1264,23 +1229,6 @@ def spec_t2cvtopt1(config: Configuration) -> None:
 # 4.4.2 PARAMETRIC INSTRUCTIONS
 
 
-def spec_drop(config: Configuration) -> None:
-    logger.debug("spec_drop()")
-
-    config.pop_operand()
-
-
-def spec_select(config: Configuration) -> None:
-    logger.debug("spec_select()")
-
-    c, val1, val2 = config.pop3_operands()
-
-    if c:
-        config.push_operand(val2)
-    else:
-        config.push_operand(val1)
-
-
 # 4.4.3 VARIABLE INSTRUCTIONS
 
 
@@ -1453,281 +1401,10 @@ def spec_memorygrow(config: Configuration) -> None:
 """
 
 
-def spec_nop(config):
-    logger.debug("spec_nop()")
-
-
-def spec_unreachable(config):
-    logger.debug("spec_unreachable()")
-
-    raise Trap("trap")
-
-
-def spec_block(config):
-    logger.debug("spec_block()")
-
-    block = cast(Block, config.instructions.current)
-    # 1
-    # 2
-    L = Label(
-        arity=len(block.result_type),
-        instructions=InstructionSequence(block.instructions),
-        is_loop=False,
-    )
-
-    # 3
-    spec_enter_block(config, L)
-
-
-def spec_loop(config: Configuration) -> None:
-    logger.debug("spec_loop()")
-
-    instruction = cast(Loop, config.instructions.current)
-    # 1
-    L = Label(
-        arity=0,
-        instructions=InstructionSequence(instruction.instructions),
-        is_loop=True,
-    )
-    # 2
-    spec_enter_block(config, L)
-
-
-def spec_if(config: Configuration) -> None:
-    logger.debug("spec_if()")
-
-    # 2
-    c = config.pop_operand()
-    # 3
-    instruction = cast(If, config.instructions.current)
-    result_type = instruction.result_type
-
-    n = len(result_type)
-    # 4
-    if c:
-        L = Label(
-            arity=n,
-            instructions=InstructionSequence(instruction.instructions),
-            is_loop=False,
-        )
-    else:
-        L = Label(
-            arity=n,
-            instructions=InstructionSequence(instruction.else_instructions),
-            is_loop=False,
-        )
-
-    spec_enter_block(config, L)
-
-
-def spec_br(config: Configuration, label_idx: LabelIdx = None) -> None:
-    logger.debug('spec_br(%s)', label_idx)
-
-    instruction = cast(Union[Br, BrIf], config.instructions.current)
-
-    if label_idx is None:
-        label_idx = instruction.label_idx
-
-    # 2
-    L = config.get_by_label_idx(label_idx)
-    logger.info('BR: arity: %d', L.arity)
-    # 3
-    # 5
-    # 6
-    valn = tuple(config.pop_operand() for _ in range(L.arity))
-
-    if L.is_loop:
-        for _ in range(label_idx):
-            config.pop_label()
-        assert config.active_label is L
-        config.instructions.seek(0)
-    else:
-        for _ in range(label_idx + 1):
-            config.pop_label()
-    # 7
-    for value in valn:
-        config.push_operand(value)
-    # 8
-
-
-def spec_br_if(config: Configuration) -> None:
-    logger.debug('spec_br_if()')
-
-    instruction = cast(BrIf, config.instructions.current)
-    # 2
-    c = config.pop_operand()
-    # 3
-    if c:
-        spec_br(config, instruction.label_idx)
-    # 4
-
-
-def spec_br_table(config):
-    logger.debug('spec_br_table()')
-
-    instruction = cast(BrTable, config.instructions.current)
-    lstar = instruction.label_indices
-    lN = instruction.default_idx
-    # 2
-    i = config.pop_operand()
-    # 3
-    if i < len(lstar):
-        li = lstar[i]
-        spec_br(config, li)
-    # 4
-    else:
-        spec_br(config, lN)
-
-
-def spec_return(config: Configuration) -> None:
-    logger.debug('spec_return()')
-
-    # 1
-    # 2
-    n = config.frame.arity
-    # 4
-    # 6
-    valn = list(reversed([
-        config.pop_operand()
-        for _ in range(n)
-    ]))
-
-    # 8
-    config.pop_frame()
-    # 9
-    for value in valn:
-        config.push_operand(value)
-
-
-def spec_call(config: Configuration) -> None:
-    logger.debug('spec_call()')
-
-    instruction = cast(Call, config.instructions.current)
-    # 1
-    # 3
-    addr = config.frame.module.func_addrs[instruction.function_idx]
-    # 4
-    spec_invoke_function_address(config, addr)
-
-
-def spec_call_indirect(config: Configuration) -> None:
-    logger.debug('spec_call_indirect()')
-
-    S = config.store
-    # 1
-    # 3
-    ta = config.frame.module.table_addrs[0]
-    # 5
-    tab = S.tables[ta]
-    # 7
-    instruction = cast(CallIndirect, config.instructions.current)
-    ftexpect = config.frame.module.types[instruction.type_idx]
-    # 9
-    i = int(config.pop_operand())
-    # 10
-    if len(tab.elem) <= i:
-        raise Trap("trap")
-    # 11
-    if tab.elem[i] is None:
-        raise Trap("trap")
-    # 12
-    addr = tab.elem[i]
-    if addr is None:
-        raise Exception("Invalid: TODO")
-    # 14
-    f = S.funcs[addr]
-    # 15
-    ftactual = f.type
-    # 16
-    if ftexpect != ftactual:
-        raise Trap("trap")
-    # 17
-    spec_invoke_function_address(config, addr)
-
-
 # 4.4.6 BLOCKS
 
 
-def spec_enter_block(config: Configuration, L: Label) -> None:
-    logger.debug('spec_enter_block(%s)', L)
-
-    config.push_label(L)
-
-
-def spec_exit_block(config):
-    logger.debug('spec_exit_block(%s)', config.active_label)
-
-    L = config.pop_label()
-    for val in L.operand_stack:
-        config.push_operand(val)
-
-
 # 4.4.7 FUNCTION CALLS
-
-def spec_invoke_function_address(config: Configuration,
-                                 func_addr: FunctionAddress = None,
-                                 ) -> None:
-    logger.debug('spec_invoke_function_address(%s)', func_addr)
-
-    S = config.store
-    if config.frame_stack_size > 1024:
-        # TODO: this is not part of spec, but this is required to pass tests.
-        # Tests pass with limit 10000, maybe more
-        raise Exhaustion("Function length greater than 1024")
-
-    if func_addr is None:
-        if isinstance(config.instructions.current, InvokeInstruction):
-            func_addr = config.instructions.current.func_addr
-        else:
-            raise TypeError(
-                "No function address was provided and cannot get address from "
-                "instruction."
-            )
-
-    # 2
-    f = S.funcs[func_addr]
-    # 3
-    t1n, t2m = f.type
-    if isinstance(f, FunctionInstance):
-        # 5
-        tstar = f.code.locals
-        # 6
-        instrstarend = f.code.body
-        # 8
-        valn = list(reversed([
-            config.pop_operand()
-            for _ in range(len(t1n))
-        ]))
-        # 9
-        val0star: List[TValue] = []
-        for valtype in tstar:
-            if valtype.is_integer_type:
-                val0star.append(UInt32(0))
-            elif valtype.is_float_type:
-                val0star.append(Float32(0.0))
-            else:
-                raise Exception(f"Invariant: unkown type '{valtype}'")
-        # 10 & 11
-        blockinstrstarendend = InstructionSequence(
-            Block.wrap_with_end(t2m, instrstarend)
-        )
-        F = Frame(
-            module=f.module,
-            locals=valn + val0star,
-            instructions=blockinstrstarendend,
-            arity=len(t2m),
-        )
-        config.push_frame(F)
-    elif isinstance(f, HostFunction):
-        valn = [config.pop_operand() for _ in range(len(t1n))]
-        _, ret = f.hostcode(S, valn)
-        if len(ret) > 1:
-            raise Exception("Invariant")
-        elif ret:
-            config.push_operand(ret[0])
-    else:
-        raise Exception("Invariant: unreachable code path")
-
 
 def spec_return_from_func(config: Configuration) -> None:
     logger.debug('spec_return_from_func()')
@@ -1746,51 +1423,28 @@ def spec_return_from_func(config: Configuration) -> None:
             config.result_stack.push(arg)
 
 
-def spec_end(config: Configuration) -> None:
-    logger.debug('spec_end()')
-
-    if config.has_active_label:
-        spec_exit_block(config)
-    elif config.has_active_frame:
-        spec_return_from_func(config)
-    else:
-        raise Exception("Invariant?")
-
-
 # 4.4.8 EXPRESSIONS
-
-
-class InvokeOp:
-    text = 'invoke'
-
-
-class InvokeInstruction(NamedTuple):
-    func_addr: FunctionAddress
-
-    @property
-    def opcode(self) -> Type[InvokeOp]:
-        return InvokeOp
 
 
 # Map each opcode to the function(s) to invoke when it is encountered. For
 # opcodes with two functions, the second function is called by the first
 # function.
-opcode2exec: Dict[Union[Type[InvokeOp], BinaryOpcode], Tuple[Callable, ...]] = {
-    BinaryOpcode.UNREACHABLE: (spec_unreachable,),
-    BinaryOpcode.NOP: (spec_nop,),
-    BinaryOpcode.BLOCK: (spec_block,),  # blocktype in* end
-    BinaryOpcode.LOOP: (spec_loop,),  # blocktype in* end
-    BinaryOpcode.IF: (spec_if,),  # blocktype in1* else? in2* end
-    BinaryOpcode.ELSE: (spec_end,),  # in2*
-    BinaryOpcode.END: (spec_end,),
-    BinaryOpcode.BR: (spec_br,),  # labelidx
-    BinaryOpcode.BR_IF: (spec_br_if,),  # labelidx
-    BinaryOpcode.BR_TABLE: (spec_br_table,),  # labelidx* labelidx
-    BinaryOpcode.RETURN: (spec_return,),
-    BinaryOpcode.CALL: (spec_call,),  # funcidx
-    BinaryOpcode.CALL_INDIRECT: (spec_call_indirect,),  # typeidx 0x00
-    BinaryOpcode.DROP: (spec_drop,),
-    BinaryOpcode.SELECT: (spec_select,),
+opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
+    # BinaryOpcode.UNREACHABLE: (spec_unreachable,),
+    # BinaryOpcode.NOP: (spec_nop,),
+    # BinaryOpcode.BLOCK: (spec_block,),  # blocktype in* end
+    # BinaryOpcode.LOOP: (spec_loop,),  # blocktype in* end
+    # BinaryOpcode.IF: (spec_if,),  # blocktype in1* else? in2* end
+    # BinaryOpcode.ELSE: (spec_end,),  # in2*
+    # BinaryOpcode.END: (spec_end,),
+    # BinaryOpcode.BR: (spec_br,),  # labelidx
+    # BinaryOpcode.BR_IF: (spec_br_if,),  # labelidx
+    # BinaryOpcode.BR_TABLE: (spec_br_table,),  # labelidx* labelidx
+    # BinaryOpcode.RETURN: (spec_return,),
+    # BinaryOpcode.CALL: (spec_call,),  # funcidx
+    # BinaryOpcode.CALL_INDIRECT: (spec_call_indirect,),  # typeidx 0x00
+    # BinaryOpcode.DROP: (spec_drop,),
+    # BinaryOpcode.SELECT: (spec_select,),
     BinaryOpcode.GET_LOCAL: (spec_get_local,),  # localidx
     BinaryOpcode.SET_LOCAL: (spec_set_local,),  # localidx
     BinaryOpcode.TEE_LOCAL: (spec_tee_local,),  # localidx
@@ -1948,8 +1602,6 @@ opcode2exec: Dict[Union[Type[InvokeOp], BinaryOpcode], Tuple[Callable, ...]] = {
     BinaryOpcode.I64_REINTERPRET_F64: (spec_t2cvtopt1, spec_reinterprett1t2),
     BinaryOpcode.F32_REINTERPRET_I32: (spec_t2cvtopt1, spec_reinterprett1t2),
     BinaryOpcode.F64_REINTERPRET_I64: (spec_t2cvtopt1, spec_reinterprett1t2),
-    # special case
-    InvokeOp: (spec_invoke_function_address,),
 }
 
 
@@ -1992,59 +1644,6 @@ def spec_growmem(meminst: MemoryInstance, n: UInt32) -> None:
 # 4.5.5 INVOCATION
 
 # valn looks like [["i32.const",3],["i32.const",199], ...]
-def spec_invoke(S: Store,
-                funcaddr: FunctionAddress,
-                valn: Tuple[Tuple[ValType, TValue], ...] = None,
-                ) -> Tuple[TValue, ...]:
-    logger.debug('spec_invoke()')
-
-    # 1
-    if len(S.funcs) < funcaddr or funcaddr < 0:
-        raise Exception("bad address")
-    # 2
-    funcinst = S.funcs[funcaddr]
-    # 5
-    t1n, t2m = funcinst.type
-    # 4
-    if valn is None:
-        valn = tuple()
-
-    if len(valn) != len(t1n):
-        raise Exception("wrong number of arguments")
-    # 5
-    for ti, (valt, val) in zip(t1n, valn):
-        if ti is not valt:
-            raise Exception("argument type mismatch")
-
-    # 6
-    # 7
-    if isinstance(funcinst, FunctionInstance):
-        F = Frame(
-            module=ModuleInstance((), (), (), (), (), ()),
-            locals=[],
-            instructions=InstructionSequence(cast(
-                Tuple[BaseInstruction, ...],
-                (InvokeInstruction(funcaddr), End()),
-            )),
-            arity=len(t2m),
-        )
-        config = Configuration(store=S)
-        config.push_frame(F)
-        for _, arg in valn:
-            config.push_operand(arg)
-
-        valresm = config.execute()
-        assert valresm is not None
-        return valresm
-    elif isinstance(funcinst, HostFunction):
-        operand_stack = OperandStack()
-        for _, arg in valn:
-            operand_stack.push(arg)
-        S, valresm = funcinst.hostcode(S, operand_stack)
-        assert valresm is not None
-        return valresm
-    else:
-        raise Exception(f"Invariant: unknown function type: {type(funcinst)}")
 
 
 ###################
@@ -2182,30 +1781,10 @@ def spec_invoke(S: Store,
 # 7.1.2 MODULES
 
 
-def decode_module(bytestar):
-    stream = io.BytesIO(bytestar)
-    try:
-        return parse_module(stream)
-    except ParseError as err:
-        raise MalformedModule from err
-
-
-def validate_module(module):
-    try:
-        _validate_module(module)
-    except ValidationError as err:
-        raise InvalidModule from err
-
-
 # 7.1.3 EXPORTS
 
 
 # 7.1.4 FUNCTIONS
-
-
-def invoke_func(store, funcaddr, valstar):
-    ret = spec_invoke(store, funcaddr, valstar)
-    return store, ret
 
 
 # 7.1.4 TABLES

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -414,266 +414,6 @@ def spec_signediN_inv(N, i):
         raise Exception(f"Invariant: bit size out of range - Got '{N}'")
 
 
-def spec_iaddN(N, i1, i2):
-    logger.debug("spec_iaddN(%s, %s, %s)", N, i1, i2)
-
-    return (i1 + i2) % 2 ** N
-
-
-def spec_isubN(N, i1, i2):
-    logger.debug("spec_isubN(%s, %s, %s)", N, i1, i2)
-
-    return (i1 - i2 + 2 ** N) % 2 ** N
-
-
-def spec_imulN(N, i1, i2):
-    logger.debug("spec_imulN(%s, %s, %s)", N, i1, i2)
-
-    return (i1 * i2) % 2 ** N
-
-
-def spec_idiv_uN(N, i1, i2):
-    logger.debug("spec_idiv_uN(%s, %s, %s)", N, i1, i2)
-
-    if i2 == 0:
-        raise Trap("trap")
-    return spec_trunc((i1, i2))
-
-
-def spec_idiv_sN(N, i1, i2):
-    logger.debug("spec_idiv_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if j2 == 0:
-        raise Trap("trap")
-    # assuming j1 and j2 are N-bit
-    if j1 // j2 == 2 ** (N - 1):
-        raise Trap("trap")
-    return spec_signediN_inv(N, spec_trunc((j1, j2)))
-
-
-def spec_irem_uN(N, i1, i2):
-    logger.debug("spec_irem_uN(%s, %s, %s)", N, i1, i2)
-
-    if i2 == 0:
-        raise Trap("trap")
-    return i1 - i2 * spec_trunc((i1, i2))
-
-
-def spec_irem_sN(N, i1, i2):
-    logger.debug("spec_irem_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if i2 == 0:
-        raise Trap("trap")
-    return spec_signediN_inv(N, j1 - j2 * spec_trunc((j1, j2)))
-
-
-def spec_iandN(N, i1, i2):
-    logger.debug("spec_iandN(%s, %s, %s)", N, i1, i2)
-
-    return i1 & i2
-
-
-def spec_iorN(N, i1, i2):
-    logger.debug("spec_iorN(%s, %s, %s)", N, i1, i2)
-
-    return i1 | i2
-
-
-def spec_ixorN(N, i1, i2):
-    logger.debug("spec_ixorN(%s, %s, %s)", N, i1, i2)
-
-    return i1 ^ i2
-
-
-def spec_ishlN(N, i1, i2):
-    logger.debug("spec_ishlN(%s, %s, %s)", N, i1, i2)
-
-    k = i2 % N
-    return (i1 << k) % (2 ** N)
-
-
-def spec_ishr_uN(N, i1, i2):
-    logger.debug("spec_ishr_uN(%s, %s, %s)", N, i1, i2)
-
-    j2 = i2 % N
-    return i1 >> j2
-
-
-def spec_ishr_sN(N, i1, i2):
-    logger.debug("spec_ishr_sN(%s, %s, %s)", N, i1, i2)
-
-    k = i2 % N
-    d0d1Nmkm1d2k = spec_ibitsN(N, i1)
-    d0 = d0d1Nmkm1d2k[0]
-    d1Nmkm1 = d0d1Nmkm1d2k[1:N - k]
-    return spec_ibitsN_inv(N, d0 * (k + 1) + d1Nmkm1)
-
-
-def spec_irotlN(N, i1, i2):
-    logger.debug("spec_irotlN(%s, %s, %s)", N, i1, i2)
-
-    k = i2 % N
-    d1kd2Nmk = spec_ibitsN(N, i1)
-    d2Nmk = d1kd2Nmk[k:]
-    d1k = d1kd2Nmk[:k]
-    return spec_ibitsN_inv(N, d2Nmk + d1k)
-
-
-def spec_irotrN(N, i1, i2):
-    logger.debug("spec_irotrN(%s, %s, %s)", N, i1, i2)
-
-    k = i2 % N
-    d1Nmkd2k = spec_ibitsN(N, i1)
-    d1Nmk = d1Nmkd2k[: N - k]
-    d2k = d1Nmkd2k[N - k:]
-    return spec_ibitsN_inv(N, d2k + d1Nmk)
-
-
-def spec_iclzN(N, i):
-    logger.debug("spec_iclzN(%s, %s)", N, i)
-
-    k = 0
-    for b in spec_ibitsN(N, i):
-        if b == "0":
-            k += 1
-        else:
-            break
-    return k
-
-
-def spec_ictzN(N, i):
-    logger.debug("spec_ictzN(%s, %s)", N, i)
-
-    k = 0
-    for b in reversed(spec_ibitsN(N, i)):
-        if b == "0":
-            k += 1
-        else:
-            break
-    return k
-
-
-def spec_ipopcntN(N, i):
-    logger.debug("spec_ipopcntN(%s, %s)", N, i)
-
-    k = 0
-    for b in spec_ibitsN(N, i):
-        if b == "1":
-            k += 1
-    return k
-
-
-def spec_ieqzN(N, i):
-    logger.debug("spec_ieqzN(%s, %s)", N, i)
-
-    if i == 0:
-        return 1
-    else:
-        return 0
-
-
-def spec_ieqN(N, i1, i2):
-    logger.debug("spec_ieqN(%s, %s, %s)", N, i1, i2)
-
-    if i1 == i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ineN(N, i1, i2):
-    logger.debug("spec_ineN(%s, %s, %s)", N, i1, i2)
-
-    if i1 != i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ilt_uN(N, i1, i2):
-    logger.debug("spec_ilt_uN(%s, %s, %s)", N, i1, i2)
-
-    if i1 < i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ilt_sN(N, i1, i2):
-    logger.debug("spec_ilt_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if j1 < j2:
-        return 1
-    else:
-        return 0
-
-
-def spec_igt_uN(N, i1, i2):
-    logger.debug("spec_igt_uN(%s, %s, %s)", N, i1, i2)
-
-    if i1 > i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_igt_sN(N, i1, i2):
-    logger.debug("spec_igt_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if j1 > j2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ile_uN(N, i1, i2):
-    logger.debug("spec_ile_uN(%s, %s, %s)", N, i1, i2)
-
-    if i1 <= i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ile_sN(N, i1, i2):
-    logger.debug("spec_ile_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if j1 <= j2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ige_uN(N, i1, i2):
-    logger.debug("spec_ige_uN(%s, %s, %s)", N, i1, i2)
-
-    if i1 >= i2:
-        return 1
-    else:
-        return 0
-
-
-def spec_ige_sN(N, i1, i2):
-    logger.debug("spec_ige_sN(%s, %s, %s)", N, i1, i2)
-
-    j1 = spec_signediN(N, i1)
-    j2 = spec_signediN(N, i2)
-    if j1 >= j2:
-        return 1
-    else:
-        return 0
-
-
 # 4.3.3 FLOATING-POINT OPERATIONS
 
 
@@ -1149,15 +889,6 @@ def spec_reinterprett1t2(t1, t2, c):
 # 4.4.1 NUMERIC INSTRUCTIONS
 
 
-def spec_tconst(config):
-    instruction = config.instructions.current
-    value = instruction.value
-
-    logger.debug("spec_tconst(%s)", value)
-
-    config.push_operand(value)
-
-
 def spec_tunop(config: Configuration) -> None:
     logger.debug("spec_tunop()")
 
@@ -1475,32 +1206,32 @@ opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
     BinaryOpcode.I64_STORE32: (spec_tstore,),  # memarg
     BinaryOpcode.MEMORY_SIZE: (spec_memorysize,),
     BinaryOpcode.MEMORY_GROW: (spec_memorygrow,),
-    BinaryOpcode.I32_CONST: (spec_tconst,),  # i32
-    BinaryOpcode.I64_CONST: (spec_tconst,),  # i64
-    BinaryOpcode.F32_CONST: (spec_tconst,),  # f32
-    BinaryOpcode.F64_CONST: (spec_tconst,),  # f64
-    BinaryOpcode.I32_EQZ: (spec_ttestop, spec_ieqzN),
-    BinaryOpcode.I32_EQ: (spec_trelop, spec_ieqN),
-    BinaryOpcode.I32_NE: (spec_trelop, spec_ineN),
-    BinaryOpcode.I32_LT_S: (spec_trelop, spec_ilt_sN),
-    BinaryOpcode.I32_LT_U: (spec_trelop, spec_ilt_uN),
-    BinaryOpcode.I32_GT_S: (spec_trelop, spec_igt_sN),
-    BinaryOpcode.I32_GT_U: (spec_trelop, spec_igt_uN),
-    BinaryOpcode.I32_LE_S: (spec_trelop, spec_ile_sN),
-    BinaryOpcode.I32_LE_U: (spec_trelop, spec_ile_uN),
-    BinaryOpcode.I32_GE_S: (spec_trelop, spec_ige_sN),
-    BinaryOpcode.I32_GE_U: (spec_trelop, spec_ige_uN),
-    BinaryOpcode.I64_EQZ: (spec_ttestop, spec_ieqzN),
-    BinaryOpcode.I64_EQ: (spec_trelop, spec_ieqN),
-    BinaryOpcode.I64_NE: (spec_trelop, spec_ineN),
-    BinaryOpcode.I64_LT_S: (spec_trelop, spec_ilt_sN),
-    BinaryOpcode.I64_LT_U: (spec_trelop, spec_ilt_uN),
-    BinaryOpcode.I64_GT_S: (spec_trelop, spec_igt_sN),
-    BinaryOpcode.I64_GT_U: (spec_trelop, spec_igt_uN),
-    BinaryOpcode.I64_LE_S: (spec_trelop, spec_ile_sN),
-    BinaryOpcode.I64_LE_U: (spec_trelop, spec_ile_uN),
-    BinaryOpcode.I64_GE_S: (spec_trelop, spec_ige_sN),
-    BinaryOpcode.I64_GE_U: (spec_trelop, spec_ige_uN),
+    # BinaryOpcode.I32_CONST: (spec_tconst,),  # i32
+    # BinaryOpcode.I64_CONST: (spec_tconst,),  # i64
+    # BinaryOpcode.F32_CONST: (spec_tconst,),  # f32
+    # BinaryOpcode.F64_CONST: (spec_tconst,),  # f64
+    # BinaryOpcode.I32_EQZ: (spec_ttestop, spec_ieqzN),
+    # BinaryOpcode.I32_EQ: (spec_trelop, spec_ieqN),
+    # BinaryOpcode.I32_NE: (spec_trelop, spec_ineN),
+    # BinaryOpcode.I32_LT_S: (spec_trelop, spec_ilt_sN),
+    # BinaryOpcode.I32_LT_U: (spec_trelop, spec_ilt_uN),
+    # BinaryOpcode.I32_GT_S: (spec_trelop, spec_igt_sN),
+    # BinaryOpcode.I32_GT_U: (spec_trelop, spec_igt_uN),
+    # BinaryOpcode.I32_LE_S: (spec_trelop, spec_ile_sN),
+    # BinaryOpcode.I32_LE_U: (spec_trelop, spec_ile_uN),
+    # BinaryOpcode.I32_GE_S: (spec_trelop, spec_ige_sN),
+    # BinaryOpcode.I32_GE_U: (spec_trelop, spec_ige_uN),
+    # BinaryOpcode.I64_EQZ: (spec_ttestop, spec_ieqzN),
+    # BinaryOpcode.I64_EQ: (spec_trelop, spec_ieqN),
+    # BinaryOpcode.I64_NE: (spec_trelop, spec_ineN),
+    # BinaryOpcode.I64_LT_S: (spec_trelop, spec_ilt_sN),
+    # BinaryOpcode.I64_LT_U: (spec_trelop, spec_ilt_uN),
+    # BinaryOpcode.I64_GT_S: (spec_trelop, spec_igt_sN),
+    # BinaryOpcode.I64_GT_U: (spec_trelop, spec_igt_uN),
+    # BinaryOpcode.I64_LE_S: (spec_trelop, spec_ile_sN),
+    # BinaryOpcode.I64_LE_U: (spec_trelop, spec_ile_uN),
+    # BinaryOpcode.I64_GE_S: (spec_trelop, spec_ige_sN),
+    # BinaryOpcode.I64_GE_U: (spec_trelop, spec_ige_uN),
     BinaryOpcode.F32_EQ: (spec_trelop, spec_feqN),
     BinaryOpcode.F32_NE: (spec_trelop, spec_fneN),
     BinaryOpcode.F32_LT: (spec_trelop, spec_fltN),
@@ -1513,42 +1244,42 @@ opcode2exec: Dict[BinaryOpcode, Tuple[Callable, ...]] = {
     BinaryOpcode.F64_GT: (spec_trelop, spec_fgtN),
     BinaryOpcode.F64_LE: (spec_trelop, spec_fleN),
     BinaryOpcode.F64_GE: (spec_trelop, spec_fgeN),
-    BinaryOpcode.I32_CLZ: (spec_tunop, spec_iclzN),
-    BinaryOpcode.I32_CTZ: (spec_tunop, spec_ictzN),
-    BinaryOpcode.I32_POPCNT: (spec_tunop, spec_ipopcntN),
-    BinaryOpcode.I32_ADD: (spec_tbinop, spec_iaddN),
-    BinaryOpcode.I32_SUB: (spec_tbinop, spec_isubN),
-    BinaryOpcode.I32_MUL: (spec_tbinop, spec_imulN),
-    BinaryOpcode.I32_DIV_S: (spec_tbinop, spec_idiv_sN),
-    BinaryOpcode.I32_DIV_U: (spec_tbinop, spec_idiv_uN),
-    BinaryOpcode.I32_REM_S: (spec_tbinop, spec_irem_sN),
-    BinaryOpcode.I32_REM_U: (spec_tbinop, spec_irem_uN),
-    BinaryOpcode.I32_AND: (spec_tbinop, spec_iandN),
-    BinaryOpcode.I32_OR: (spec_tbinop, spec_iorN),
-    BinaryOpcode.I32_XOR: (spec_tbinop, spec_ixorN),
-    BinaryOpcode.I32_SHL: (spec_tbinop, spec_ishlN),
-    BinaryOpcode.I32_SHR_S: (spec_tbinop, spec_ishr_sN),
-    BinaryOpcode.I32_SHR_U: (spec_tbinop, spec_ishr_uN),
-    BinaryOpcode.I32_ROTL: (spec_tbinop, spec_irotlN),
-    BinaryOpcode.I32_ROTR: (spec_tbinop, spec_irotrN),
-    BinaryOpcode.I64_CLZ: (spec_tunop, spec_iclzN),
-    BinaryOpcode.I64_CTZ: (spec_tunop, spec_ictzN),
-    BinaryOpcode.I64_POPCNT: (spec_tunop, spec_ipopcntN),
-    BinaryOpcode.I64_ADD: (spec_tbinop, spec_iaddN),
-    BinaryOpcode.I64_SUB: (spec_tbinop, spec_isubN),
-    BinaryOpcode.I64_MUL: (spec_tbinop, spec_imulN),
-    BinaryOpcode.I64_DIV_S: (spec_tbinop, spec_idiv_sN),
-    BinaryOpcode.I64_DIV_U: (spec_tbinop, spec_idiv_uN),
-    BinaryOpcode.I64_REM_S: (spec_tbinop, spec_irem_sN),
-    BinaryOpcode.I64_REM_U: (spec_tbinop, spec_irem_uN),
-    BinaryOpcode.I64_AND: (spec_tbinop, spec_iandN),
-    BinaryOpcode.I64_OR: (spec_tbinop, spec_iorN),
-    BinaryOpcode.I64_XOR: (spec_tbinop, spec_ixorN),
-    BinaryOpcode.I64_SHL: (spec_tbinop, spec_ishlN),
-    BinaryOpcode.I64_SHR_S: (spec_tbinop, spec_ishr_sN),
-    BinaryOpcode.I64_SHR_U: (spec_tbinop, spec_ishr_uN),
-    BinaryOpcode.I64_ROTL: (spec_tbinop, spec_irotlN),
-    BinaryOpcode.I64_ROTR: (spec_tbinop, spec_irotrN),
+    # BinaryOpcode.I32_CLZ: (spec_tunop, spec_iclzN),
+    # BinaryOpcode.I32_CTZ: (spec_tunop, spec_ictzN),
+    # BinaryOpcode.I32_POPCNT: (spec_tunop, spec_ipopcntN),
+    # BinaryOpcode.I32_ADD: (spec_tbinop, spec_iaddN),
+    # BinaryOpcode.I32_SUB: (spec_tbinop, spec_isubN),
+    # BinaryOpcode.I32_MUL: (spec_tbinop, spec_imulN),
+    # BinaryOpcode.I32_DIV_S: (spec_tbinop, spec_idiv_sN),
+    # BinaryOpcode.I32_DIV_U: (spec_tbinop, spec_idiv_uN),
+    # BinaryOpcode.I32_REM_S: (spec_tbinop, spec_irem_sN),
+    # BinaryOpcode.I32_REM_U: (spec_tbinop, spec_irem_uN),
+    # BinaryOpcode.I32_AND: (spec_tbinop, spec_iandN),
+    # BinaryOpcode.I32_OR: (spec_tbinop, spec_iorN),
+    # BinaryOpcode.I32_XOR: (spec_tbinop, spec_ixorN),
+    # BinaryOpcode.I32_SHL: (spec_tbinop, spec_ishlN),
+    # BinaryOpcode.I32_SHR_S: (spec_tbinop, spec_ishr_sN),
+    # BinaryOpcode.I32_SHR_U: (spec_tbinop, spec_ishr_uN),
+    # BinaryOpcode.I32_ROTL: (spec_tbinop, spec_irotlN),
+    # BinaryOpcode.I32_ROTR: (spec_tbinop, spec_irotrN),
+    # BinaryOpcode.I64_CLZ: (spec_tunop, spec_iclzN),
+    # BinaryOpcode.I64_CTZ: (spec_tunop, spec_ictzN),
+    # BinaryOpcode.I64_POPCNT: (spec_tunop, spec_ipopcntN),
+    # BinaryOpcode.I64_ADD: (spec_tbinop, spec_iaddN),
+    # BinaryOpcode.I64_SUB: (spec_tbinop, spec_isubN),
+    # BinaryOpcode.I64_MUL: (spec_tbinop, spec_imulN),
+    # BinaryOpcode.I64_DIV_S: (spec_tbinop, spec_idiv_sN),
+    # BinaryOpcode.I64_DIV_U: (spec_tbinop, spec_idiv_uN),
+    # BinaryOpcode.I64_REM_S: (spec_tbinop, spec_irem_sN),
+    # BinaryOpcode.I64_REM_U: (spec_tbinop, spec_irem_uN),
+    # BinaryOpcode.I64_AND: (spec_tbinop, spec_iandN),
+    # BinaryOpcode.I64_OR: (spec_tbinop, spec_iorN),
+    # BinaryOpcode.I64_XOR: (spec_tbinop, spec_ixorN),
+    # BinaryOpcode.I64_SHL: (spec_tbinop, spec_ishlN),
+    # BinaryOpcode.I64_SHR_S: (spec_tbinop, spec_ishr_sN),
+    # BinaryOpcode.I64_SHR_U: (spec_tbinop, spec_ishr_uN),
+    # BinaryOpcode.I64_ROTL: (spec_tbinop, spec_irotlN),
+    # BinaryOpcode.I64_ROTR: (spec_tbinop, spec_irotrN),
     BinaryOpcode.F32_ABS: (spec_tunop, spec_fabsN),
     BinaryOpcode.F32_NEG: (spec_tunop, spec_fnegN),
     BinaryOpcode.F32_CEIL: (spec_tunop, spec_fceilN),

--- a/wasm/tools/fixtures/datatypes.py
+++ b/wasm/tools/fixtures/datatypes.py
@@ -2,15 +2,18 @@ from pathlib import (
     Path,
 )
 from typing import (
-    TYPE_CHECKING,
     NamedTuple,
     Optional,
     Tuple,
     Union,
 )
 
-if TYPE_CHECKING:
-    from wasm.datatypes import ValType  # noqa: F401
+from wasm.datatypes import (
+    ValType,
+)
+from wasm.typing import (
+    TValue,
+)
 
 
 class ModuleCommand(NamedTuple):
@@ -20,13 +23,13 @@ class ModuleCommand(NamedTuple):
 
 
 class Argument(NamedTuple):
-    type: 'ValType'
-    value: Union[int, float]
+    valtype: ValType
+    value: TValue
 
 
 class Expected(NamedTuple):
-    type: 'ValType'
-    value: Union[None, int, float]
+    valtype: ValType
+    value: Union[None, TValue]
 
 
 class Action(NamedTuple):

--- a/wasm/tools/fixtures/generation.py
+++ b/wasm/tools/fixtures/generation.py
@@ -3,6 +3,7 @@ from pathlib import (
 )
 from typing import (
     Any,
+    Tuple,
 )
 
 from .loading import (
@@ -17,8 +18,27 @@ def idfn(fixture_path: Path) -> str:
     return str(fixture_path.resolve())
 
 
+SLOW_FIXTURES = {
+    'call.wast.json',
+    'call_indirect.wast.json',
+    'memory_grow.wast.json',
+    'skip-stack-guard-page.wast.json',
+}
+
+
+def mark_fixtures(all_fixture_paths: Tuple[Path, ...], skip_slow):
+    import pytest
+
+    for fixture_path in sorted(all_fixture_paths):
+        if skip_slow and fixture_path.name in SLOW_FIXTURES:
+            yield pytest.param(fixture_path, marks=pytest.mark.skip("slow"))
+        else:
+            yield fixture_path
+
+
 def generate_fixture_tests(metafunc: Any,
-                           fixtures_dir: Path) -> None:
+                           fixtures_dir: Path,
+                           skip_slow: bool) -> None:
     """
     Helper function for use with `pytest_generate_tests` to generate fixture tests.
 
@@ -26,7 +46,10 @@ def generate_fixture_tests(metafunc: Any,
     - `fixtures_dir` is the base path that fixture files will be collected from.
     """
     if 'fixture_path' in metafunc.fixturenames:
-        all_fixture_paths = tuple(sorted(find_json_fixture_files(fixtures_dir)))
+        all_fixture_paths = tuple(mark_fixtures(
+            all_fixture_paths=find_json_fixture_files(fixtures_dir),
+            skip_slow=skip_slow,
+        ))
         if len(all_fixture_paths) == 0:
             raise Exception("Invariant: found zero fixtures")
 

--- a/wasm/tools/fixtures/modules.py
+++ b/wasm/tools/fixtures/modules.py
@@ -1,4 +1,7 @@
 import logging
+from typing import (
+    Tuple,
+)
 
 from wasm.datatypes import (
     ExportInstance,
@@ -16,9 +19,13 @@ from wasm.datatypes import (
     TableType,
     ValType,
 )
+from wasm.execution import (
+    Configuration,
+)
 from wasm.typing import (
     Float32,
     Float64,
+    TValue,
     UInt32,
 )
 
@@ -26,33 +33,35 @@ from wasm.typing import (
 def instantiate_spectest_module(store: Store) -> ModuleInstance:
     logger = logging.getLogger("wasm.tools.fixtures.modules.spectest")
 
-    def spectest__print_i32(store, arg):
-        logger.debug('print_i32: %s', arg)
-        return store, []
+    def spectest__print_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i32: %s', args)
+        return tuple()
 
-    def spectest__print_i64(store, arg):
-        logger.debug('print_i64: %s', arg)
-        return store, []
+    def spectest__print_i64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i64: %s', args)
+        return tuple()
 
-    def spectest__print_f32(store, arg):
-        logger.debug('print_f32: %s', arg)
-        return store, []
+    def spectest__print_f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f32: %s', args)
+        return tuple()
 
-    def spectest__print_f64(store, arg):
-        logger.debug('print_f64: %s', arg)
-        return store, []
+    def spectest__print_f64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f64: %s', args)
+        return tuple()
 
-    def spectest__print_i32_f32(store, arg):
-        logger.debug('print_i32_f32: %s', arg)
-        return store, []
+    def spectest__print_i32_f32(config: Configuration,
+                                args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_i32_f32: %s', args)
+        return tuple()
 
-    def spectest__print_f64_f64(store, arg):
-        logger.debug('print_f64_f64: %s', arg)
-        return store, []
+    def spectest__print_f64_f64(config: Configuration,
+                                args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print_f64_f64: %s', args)
+        return tuple()
 
-    def spectest__print(store, arg):
-        logger.debug('print: %s', arg)
-        return store, []
+    def spectest__print(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        logger.debug('print: %s', args)
+        return tuple()
 
     store.allocate_host_function(FunctionType((ValType.i32,), ()), spectest__print_i32)
     store.allocate_host_function(FunctionType((ValType.i64,), ()), spectest__print_i64)
@@ -112,40 +121,46 @@ def instantiate_spectest_module(store: Store) -> ModuleInstance:
 
 
 # this module called "wast" is used by import.wast to test for assert_unlinkable
-def instantiate_test_module(store):
-    def test__func(store, arg):
-        pass
+def instantiate_test_module(store: Store) -> ModuleInstance:
+    def test__func(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i32(store, arg):
-        pass
+    def test__func_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_f32(store, arg):
-        pass
+    def test__func_f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func__i32(store, arg):
-        pass
+    def test__func__i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func__f32(store, arg):
-        pass
+    def test__func__f32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i32_i32(store, arg):
-        pass
+    def test__func_i32_i32(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
-    def test__func_i64_i64(store, arg):
-        pass
+    def test__func_i64_i64(config: Configuration, args: Tuple[TValue, ...]) -> Tuple[TValue, ...]:
+        return tuple()
 
     store.allocate_host_function(FunctionType((), ()), test__func)
     store.allocate_host_function(FunctionType((ValType.i32,), ()), test__func_i32)
     store.allocate_host_function(FunctionType((ValType.f32,), ()), test__func_f32)
     store.allocate_host_function(FunctionType((), (ValType.i32,)), test__func__i32)
     store.allocate_host_function(FunctionType((), (ValType.f32,)), test__func__f32)
-    store.allocate_host_function(FunctionType((ValType.i32,), (ValType.i32,)), test__func_i32_i32)
-    store.allocate_host_function(FunctionType((ValType.i64,), (ValType.i64,)), test__func_i64_i64)
+    store.allocate_host_function(
+        FunctionType((ValType.i32,), (ValType.i32,)),
+        test__func_i32_i32,
+    )
+    store.allocate_host_function(
+        FunctionType((ValType.i64,), (ValType.i64,)),
+        test__func_i64_i64,
+    )
 
-    store.allocate_memory(MemoryType(1, None))
+    store.allocate_memory(MemoryType(UInt32(1), None))
     store.allocate_global(GlobalType(Mutability.const, ValType.i32), UInt32(666))
     store.allocate_global(GlobalType(Mutability.const, ValType.f32), Float32(0.0))
-    store.allocate_table(TableType(Limits(10, None), FunctionAddress))
+    store.allocate_table(TableType(Limits(UInt32(10), None), FunctionAddress))
     moduleinst = ModuleInstance(
         types=(
             FunctionType((), ()),

--- a/wasm/tools/fixtures/normalizers.py
+++ b/wasm/tools/fixtures/normalizers.py
@@ -18,6 +18,11 @@ from mypy_extensions import (
 from wasm.datatypes import (
     ValType,
 )
+from wasm.typing import (
+    TValue,
+    UInt32,
+    UInt64,
+)
 
 from .datatypes import (
     Action,
@@ -73,21 +78,21 @@ def normalize_argument(raw_argument: RawCommand) -> Argument:
         raise Exception(f"Unexpected keys: {extra_keys}")
 
     raw_type = raw_argument['type']
-    type_ = ValType.from_str(raw_type)
+    valtype = ValType.from_str(raw_type)
 
-    value: Union[int, float]
+    value: TValue
 
-    if type_.is_integer_type:
-        value = int(raw_argument['value'])
-    elif type_ is ValType.f32:
-        value = int_to_float(32, int(raw_argument['value']))
-    elif type_ is ValType.f64:
-        value = int_to_float(64, int(raw_argument['value']))
+    if valtype is ValType.i32:
+        value = UInt32(int(raw_argument['value']))
+    elif valtype is ValType.i64:
+        value = UInt64(int(raw_argument['value']))
+    elif valtype.is_float_type:
+        value = int_to_float(valtype.bit_size.value, int(raw_argument['value']))
     else:
-        raise Exception(f"Unhandled type: {type_} | value: {raw_argument['value']}")
+        raise Exception(f"Unhandled type: {valtype} | value: {raw_argument['value']}")
 
     return Argument(
-        type=type_,
+        valtype=valtype,
         value=value,
     )
 
@@ -136,24 +141,24 @@ def normalize_expected(raw_expected: RawCommand) -> Expected:
         raise Exception(f"Unexpected keys: {extra_keys}")
 
     raw_type = raw_expected['type']
-    type_ = ValType.from_str(raw_type)
+    valtype = ValType.from_str(raw_type)
 
     value: Optional[Union[int, float]]
 
     if 'value' in raw_expected:
-        if type_.is_integer_type:
-            value = int(raw_expected['value'])
-        elif type_ is ValType.f32:
-            value = int_to_float(32, int(raw_expected['value']))
-        elif type_ is ValType.f64:
-            value = int_to_float(64, int(raw_expected['value']))
+        if valtype is ValType.i32:
+            value = UInt32(int(raw_expected['value']))
+        elif valtype is ValType.i64:
+            value = UInt64(int(raw_expected['value']))
+        elif valtype.is_float_type:
+            value = int_to_float(valtype.bit_size.value, int(raw_expected['value']))
         else:
-            raise Exception(f"Unhandled type: {type_} | value: {raw_expected['value']}")
+            raise Exception(f"Unhandled type: {valtype} | value: {raw_expected['value']}")
     else:
         value = None
 
     return Expected(
-        type=type_,
+        valtype=valtype,
         value=value,
     )
 

--- a/wasm/tools/fixtures/numeric.py
+++ b/wasm/tools/fixtures/numeric.py
@@ -1,18 +1,26 @@
 import struct
+from typing import (
+    Union,
+)
+
+from wasm.typing import (
+    Float32,
+    Float64,
+)
 
 
-def int_to_float(num_bits: int, value: int) -> float:
+def int_to_float(num_bits: int, value: int) -> Union[Float32, Float64]:
     """
     Convert an integer to the equivalent floating point value.
     """
+    value_as_bytes = value.to_bytes(num_bits // 8, 'big')
+
     if num_bits == 32:
-        unpack_fmt = '>f'
+        return Float32(struct.unpack('>f', value_as_bytes)[0])
     elif num_bits == 64:
-        unpack_fmt = '>d'
+        return Float32(struct.unpack('>d', value_as_bytes)[0])
     else:
         raise Exception(f"Unhandled bit size: {num_bits}")
-
-    return struct.unpack(unpack_fmt, value.to_bytes(num_bits // 8, 'big'))[0]
 
 
 def get_bit_size(_type: str) -> int:

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -1,13 +1,7 @@
 from typing import (
-    Any,
-    Callable,
     NewType,
-    Tuple,
     Union,
 )
-
-HostFunctionCallable = Callable[[Any, Any], Tuple[Any, Any]]
-
 
 UInt8 = NewType('UInt8', int)
 UInt32 = NewType('UInt32', int)


### PR DESCRIPTION
## What was wrong?

Existing implementation of floating point logic functions is still in the legacy module.

## How was it fixed?

Re-implemented operations under new execution paradigm.  Also found that the spec-tests do not hit many of the `+/- infinity` cases which are defined in the spec so I included some unit tests for the comparisons.

This also adds the ability to skip the slowest spec tests with `--skip-slow-spec` when running tests.

#### Cute Animal Picture

![dogclothes1112](https://user-images.githubusercontent.com/824194/52503531-0e3c3080-2ba3-11e9-803c-2296fad13460.jpeg)