### PR TITLE
Memoize frame, label, operand stack, and instruction values

### DIFF
--- a/tests/core/execution/test_configuration_object.py
+++ b/tests/core/execution/test_configuration_object.py
@@ -56,7 +56,7 @@ def test_configuration_has_active_frame(config):
 
 
 def test_configuration_frame_property(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.frame
 
     frame_a = mk_frame()
@@ -121,13 +121,13 @@ def test_configuration_cannot_pop_frame_with_active_label(config):
 
 
 def test_configuration_active_label_property(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.active_label
 
     frame_a = mk_frame()
     config.push_frame(frame_a)
 
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.active_label
 
     label_a = mk_label()
@@ -144,7 +144,7 @@ def test_configuration_active_label_property(config):
     frame_b = mk_frame()
     config.push_frame(frame_b)
 
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.active_label
 
     label_c = mk_label()
@@ -154,7 +154,7 @@ def test_configuration_active_label_property(config):
 
 
 def test_configuration_instructions_property(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.instructions
 
     frame_a = mk_frame()
@@ -184,7 +184,7 @@ def test_configuration_instructions_property(config):
 
 
 def test_configuration_push_and_pop_from_operand_stack(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.push_operand(0)
 
     frame_a = mk_frame()
@@ -210,7 +210,7 @@ def test_configuration_push_and_pop_from_operand_stack(config):
 
 
 def test_configuration_push_and_pop_u32_from_operand_stack(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.push_operand(0)
 
     frame_a = mk_frame()
@@ -229,7 +229,7 @@ def test_configuration_push_and_pop_u32_from_operand_stack(config):
 
 
 def test_configuration_push_and_pop_u64_from_operand_stack(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.push_operand(0)
 
     frame_a = mk_frame()
@@ -248,7 +248,7 @@ def test_configuration_push_and_pop_u64_from_operand_stack(config):
 
 
 def test_configuration_get_label_by_idx(config):
-    with pytest.raises(IndexError):
+    with pytest.raises(AttributeError):
         config.push_operand(0)
 
     frame = mk_frame()

--- a/tests/core/execution/test_configuration_object.py
+++ b/tests/core/execution/test_configuration_object.py
@@ -24,22 +24,22 @@ def mk_label():
 
 
 def test_configuration_frame_stack_size(config):
-    assert config.frame_stack_size == 0
+    assert len(config._frame_stack) == 0
 
     frame_a = mk_frame()
     config.push_frame(frame_a)
 
-    assert config.frame_stack_size == 1
+    assert len(config._frame_stack) == 1
 
     frame_b = mk_frame()
     config.push_frame(frame_b)
 
-    assert config.frame_stack_size == 2
+    assert len(config._frame_stack) == 2
 
     assert config.pop_frame() is frame_b
     assert config.pop_frame() is frame_a
 
-    assert config.frame_stack_size == 0
+    assert len(config._frame_stack) == 0
 
 
 def test_configuration_has_active_frame(config):
@@ -56,22 +56,21 @@ def test_configuration_has_active_frame(config):
 
 
 def test_configuration_frame_property(config):
-    with pytest.raises(AttributeError):
-        config.frame
+    assert not hasattr(config, 'frame')
 
     frame_a = mk_frame()
     config.push_frame(frame_a)
 
-    assert config.frame is frame_a
+    assert config._frame is frame_a
 
     frame_b = mk_frame()
     config.push_frame(frame_b)
 
-    assert config.frame is frame_b
+    assert config._frame is frame_b
 
     assert config.pop_frame() is frame_b
 
-    assert config.frame is frame_a
+    assert config._frame is frame_a
 
 
 def test_configuration_has_active_label(config):
@@ -120,67 +119,33 @@ def test_configuration_cannot_pop_frame_with_active_label(config):
         config.pop_frame()
 
 
-def test_configuration_active_label_property(config):
-    with pytest.raises(AttributeError):
-        config.active_label
-
-    frame_a = mk_frame()
-    config.push_frame(frame_a)
-
-    with pytest.raises(AttributeError):
-        config.active_label
-
-    label_a = mk_label()
-    config.push_label(label_a)
-
-    assert config.active_label is label_a
-
-    label_b = mk_label()
-    config.push_label(label_b)
-
-    assert config.active_label is label_b
-
-    # now push a new frame and there should not be an active label
-    frame_b = mk_frame()
-    config.push_frame(frame_b)
-
-    with pytest.raises(AttributeError):
-        config.active_label
-
-    label_c = mk_label()
-    config.push_label(label_c)
-
-    assert config.active_label is label_c
-
-
 def test_configuration_instructions_property(config):
-    with pytest.raises(AttributeError):
-        config.instructions
+    assert not hasattr(config, '_instructions')
 
     frame_a = mk_frame()
     config.push_frame(frame_a)
 
-    assert config.instructions is frame_a.instructions
+    assert config._instructions is frame_a.instructions
 
     label_a = mk_label()
     config.push_label(label_a)
 
-    assert config.instructions is label_a.instructions
+    assert config._instructions is label_a.instructions
 
     frame_b = mk_frame()
     config.push_frame(frame_b)
 
-    assert config.instructions is frame_b.instructions
+    assert config._instructions is frame_b.instructions
 
     label_b = mk_label()
     config.push_label(label_b)
 
-    assert config.instructions is label_b.instructions
+    assert config._instructions is label_b.instructions
 
     label_c = mk_label()
     config.push_label(label_c)
 
-    assert config.instructions is label_c.instructions
+    assert config._instructions is label_c.instructions
 
 
 def test_configuration_push_and_pop_from_operand_stack(config):
@@ -263,10 +228,10 @@ def test_configuration_get_label_by_idx(config):
     label_0 = mk_label()
     config.push_label(label_0)
 
-    assert config.get_by_label_idx(0) is label_0
-    assert config.get_by_label_idx(1) is label_1
-    assert config.get_by_label_idx(2) is label_2
-    assert config.get_by_label_idx(3) is label_3
+    assert config.get_label_by_idx(0) is label_0
+    assert config.get_label_by_idx(1) is label_1
+    assert config.get_label_by_idx(2) is label_2
+    assert config.get_label_by_idx(3) is label_3
 
     with pytest.raises(IndexError):
-        assert config.get_by_label_idx(4)
+        assert config.get_label_by_idx(4)

--- a/wasm/datatypes/bit_size.py
+++ b/wasm/datatypes/bit_size.py
@@ -30,7 +30,7 @@ class BitSize(enum.Enum):
     b32 = numpy.uint8(32)
     b64 = numpy.uint8(64)
 
-    def unpack_int_bytes(self, raw_bytes: bytes, signed: bool) -> TUnpack:
+    def unpack_int_bytes(self, raw_bytes: Union[memoryview, bytes], signed: bool) -> TUnpack:
         if self is self.b8:
             if signed:
                 return numpy.frombuffer(raw_bytes, numpy.int8)[0]

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -4,6 +4,7 @@ from abc import (
 )
 from typing import (
     Iterable,
+    List,
     Tuple,
     cast,
 )
@@ -12,7 +13,14 @@ import numpy
 
 from wasm.datatypes import (
     LabelIdx,
+    ModuleInstance,
     Store,
+)
+from wasm.exceptions import (
+    Exhaustion,
+)
+from wasm.instructions import (
+    BaseInstruction,
 )
 from wasm.typing import (
     TValue,
@@ -34,7 +42,7 @@ class BaseConfiguration(ABC):
     Base class for the Configuration object used for execution Web Assembly
     """
     store: Store
-    frame: Frame
+    current_instruction: BaseInstruction
 
     def __init__(self, store: Store) -> None:
         self.store = store
@@ -44,9 +52,28 @@ class BaseConfiguration(ABC):
     def execute(self) -> Tuple[TValue, ...]:
         pass
 
+    @abstractmethod
+    def seek_to_instruction_idx(self, index: int) -> None:
+        pass
+
     @property
     @abstractmethod
     def has_active_frame(self) -> bool:
+        pass
+
+    @property
+    @abstractmethod
+    def frame_arity(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def frame_locals(self) -> List[TValue]:
+        pass
+
+    @property
+    @abstractmethod
+    def frame_module(self) -> ModuleInstance:
         pass
 
     @property
@@ -57,11 +84,6 @@ class BaseConfiguration(ABC):
     @property
     @abstractmethod
     def active_label(self) -> Label:
-        pass
-
-    @property
-    @abstractmethod
-    def instructions(self) -> InstructionSequence:
         pass
 
     #
@@ -166,11 +188,6 @@ class BaseConfiguration(ABC):
     #
     # Frames
     #
-    @property
-    @abstractmethod
-    def frame_stack_size(self) -> int:
-        pass
-
     @abstractmethod
     def push_frame(self, frame: Frame) -> None:
         pass
@@ -182,11 +199,6 @@ class BaseConfiguration(ABC):
     #
     # Labels
     #
-    @property
-    @abstractmethod
-    def label_stack_size(self) -> int:
-        pass
-
     @abstractmethod
     def push_label(self, label: Label) -> None:
         pass
@@ -196,7 +208,7 @@ class BaseConfiguration(ABC):
         pass
 
     @abstractmethod
-    def get_by_label_idx(self, key: LabelIdx) -> Label:
+    def get_label_by_idx(self, key: LabelIdx) -> Label:
         pass
 
 
@@ -205,22 +217,36 @@ class Configuration(BaseConfiguration):
     An implementation of the configuration API that uses separate stacks for
     frames, labels, and operands.
     """
-    frame_stack: FrameStack
+    _frame_stack: FrameStack
+    _frame: Frame
+    _instructions: InstructionSequence
+    _operand_stack: OperandStack
 
     def __init__(self, store: Store) -> None:
         super().__init__(store)
-        self.frame_stack = FrameStack()
+        self._frame_stack = FrameStack()
 
     def execute(self) -> Tuple[TValue, ...]:
         from wasm.logic import OPCODE_TO_LOGIC_FN
 
         while True:
+            # This loop has been written the following way for performance
+            # reasons and should not be optimized for readability without
+            # taking performance into account.
+            #
+            # 1. Use of direct call to `instructions.__next__()` to avoid extra
+            #    call frame of using `next` builtin
+            # 2. Catching `AttributeError` on access to `self.instructions` to
+            #    avoid extra cost of checking if the attribute is present.
             try:
-                instruction = next(self.instructions)
+                instructions = self._instructions
             except AttributeError:
+                del self.current_instruction
                 break
 
-            logic_fn = OPCODE_TO_LOGIC_FN[instruction.opcode]
+            self.current_instruction = instructions.__next__()
+
+            logic_fn = OPCODE_TO_LOGIC_FN[self.current_instruction.opcode]
 
             logic_fn(self)
 
@@ -231,27 +257,38 @@ class Configuration(BaseConfiguration):
         else:
             return tuple()
 
+    def seek_to_instruction_idx(self, index: int) -> None:
+        self._instructions.seek(index)
+
     @property
     def has_active_frame(self) -> bool:
         try:
-            return bool(self.frame)
+            return bool(self._frame)
         except AttributeError:
             return False
 
     @property
+    def frame_arity(self) -> int:
+        return self._frame.arity
+
+    @property
+    def frame_locals(self) -> List[TValue]:
+        return self._frame.locals
+
+    @property
+    def frame_module(self) -> ModuleInstance:
+        return self._frame.module
+
+    @property
     def active_label(self) -> Label:
-        return self.frame.label
+        return self._frame.label
 
     @property
     def has_active_label(self) -> bool:
         try:
-            return bool(self.frame.label)
+            return bool(self._frame.label)
         except AttributeError:
             return False
-
-    @property
-    def instructions(self) -> InstructionSequence:
-        return self.frame.active_instructions
 
     #
     # Results
@@ -267,113 +304,121 @@ class Configuration(BaseConfiguration):
     #
     @property
     def operand_stack_size(self) -> int:
-        return len(self.frame.active_operand_stack)
+        return len(self._operand_stack)
 
     def push_operand(self, value: TValue) -> None:
-        self.frame.active_operand_stack.push(value)
+        self._operand_stack.push(value)
 
     def extend_operands(self, values: Iterable[TValue]) -> None:
-        self.frame.active_operand_stack.extend(values)
+        self._operand_stack.extend(values)
 
     def pop_operand(self) -> TValue:
-        return self.frame.active_operand_stack.pop()
+        return self._operand_stack.pop()
 
     def pop2_operands(self) -> Tuple[TValue, TValue]:
-        return self.frame.active_operand_stack.pop2()
+        return self._operand_stack.pop2()
 
     def pop3_operands(self) -> Tuple[TValue, TValue, TValue]:
-        return self.frame.active_operand_stack.pop3()
+        return self._operand_stack.pop3()
 
     #
     # Pop u32
     #
     def pop_u32(self) -> numpy.uint32:
-        return cast(numpy.uint32, self.frame.active_operand_stack.pop())
+        return cast(numpy.uint32, self._operand_stack.pop())
 
     def pop2_u32(self) -> Tuple[numpy.uint32, numpy.uint32]:
-        a, b = self.frame.active_operand_stack.pop2()
+        a, b = self._operand_stack.pop2()
         return cast(numpy.uint32, a), cast(numpy.uint32, b)
 
     def pop3_u32(self) -> Tuple[numpy.uint32, numpy.uint32, numpy.uint32]:
-        a, b, c = self.frame.active_operand_stack.pop3()
+        a, b, c = self._operand_stack.pop3()
         return cast(numpy.uint32, a), cast(numpy.uint32, b), cast(numpy.uint32, c)
 
     #
     # Pop u64
     #
     def pop_u64(self) -> numpy.uint64:
-        return cast(numpy.uint64, self.frame.active_operand_stack.pop())
+        return cast(numpy.uint64, self._operand_stack.pop())
 
     def pop2_u64(self) -> Tuple[numpy.uint64, numpy.uint64]:
-        a, b = self.frame.active_operand_stack.pop2()
+        a, b = self._operand_stack.pop2()
         return cast(numpy.uint64, a), cast(numpy.uint64, b)
 
     def pop3_u64(self) -> Tuple[numpy.uint64, numpy.uint64, numpy.uint64]:
-        a, b, c = self.frame.active_operand_stack.pop3()
+        a, b, c = self._operand_stack.pop3()
         return cast(numpy.uint64, a), cast(numpy.uint64, b), cast(numpy.uint64, c)
 
     #
     # Pop f32
     #
     def pop_f32(self) -> numpy.float32:
-        return cast(numpy.float32, self.frame.active_operand_stack.pop())
+        return cast(numpy.float32, self._operand_stack.pop())
 
     def pop2_f32(self) -> Tuple[numpy.float32, numpy.float32]:
-        a, b = self.frame.active_operand_stack.pop2()
+        a, b = self._operand_stack.pop2()
         return cast(numpy.float32, a), cast(numpy.float32, b)
 
     def pop3_f32(self) -> Tuple[numpy.float32, numpy.float32, numpy.float32]:
-        a, b, c = self.frame.active_operand_stack.pop3()
+        a, b, c = self._operand_stack.pop3()
         return cast(numpy.float32, a), cast(numpy.float32, b), cast(numpy.float32, c)
 
     #
     # Pop f64
     #
     def pop_f64(self) -> numpy.float64:
-        return cast(numpy.float64, self.frame.active_operand_stack.pop())
+        return cast(numpy.float64, self._operand_stack.pop())
 
     def pop2_f64(self) -> Tuple[numpy.float64, numpy.float64]:
-        a, b = self.frame.active_operand_stack.pop2()
+        a, b = self._operand_stack.pop2()
         return cast(numpy.float64, a), cast(numpy.float64, b)
 
     def pop3_f64(self) -> Tuple[numpy.float64, numpy.float64, numpy.float64]:
-        a, b, c = self.frame.active_operand_stack.pop3()
+        a, b, c = self._operand_stack.pop3()
         return cast(numpy.float64, a), cast(numpy.float64, b), cast(numpy.float64, c)
 
     #
     # Frames
     #
-    @property
-    def frame_stack_size(self) -> int:
-        return len(self.frame_stack)
-
     def push_frame(self, frame: Frame) -> None:
-        self.frame = frame
-        self.frame_stack.push(frame)
+        if len(self._frame_stack) > 1024:
+            # This is not part of spec, but this is required to pass tests.
+            # Tests pass with limit 10000, maybe more
+            raise Exhaustion("Too many call frames.  Cannot exceed 1024")
+
+        self._frame = frame
+        self._frame_stack.push(frame)
+        self._operand_stack = self._frame.active_operand_stack
+        self._instructions = self._frame.active_instructions
 
     def pop_frame(self) -> Frame:
         if self.has_active_label:
             raise ValueError("Cannot pop frame while there is an active label")
-        frame = self.frame_stack.pop()
+        frame = self._frame_stack.pop()
         try:
-            self.frame = self.frame_stack.peek()
+            self._frame = self._frame_stack.peek()
+            self._operand_stack = self._frame.active_operand_stack
+            self._instructions = self._frame.active_instructions
         except IndexError:
-            del self.frame
+            del self._frame
+            del self._operand_stack
+            del self._instructions
 
         return frame
 
     #
     # Labels
     #
-    @property
-    def label_stack_size(self) -> int:
-        return len(self.frame.control_stack)
-
     def push_label(self, label: Label) -> None:
-        self.frame.push_label(label)
+        self._frame.push_label(label)
+        self._operand_stack = label.operand_stack
+        self._instructions = label.instructions
 
     def pop_label(self) -> Label:
-        return self.frame.pop_label()
+        label = self._frame.pop_label()
+        self._operand_stack = self._frame.active_operand_stack
+        self._instructions = self._frame.active_instructions
+        return label
 
-    def get_by_label_idx(self, key: LabelIdx) -> Label:
-        return self.frame.control_stack.get_by_label_idx(key)
+    def get_label_by_idx(self, key: LabelIdx) -> Label:
+        return self._frame.control_stack.get_label_by_idx(key)

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -214,8 +214,11 @@ class Configuration(BaseConfiguration):
     def execute(self) -> Tuple[TValue, ...]:
         from wasm.logic import OPCODE_TO_LOGIC_FN
 
-        while self.has_active_frame:
-            instruction = next(self.instructions)
+        while True:
+            try:
+                instruction = next(self.instructions)
+            except AttributeError:
+                break
 
             logic_fn = OPCODE_TO_LOGIC_FN[instruction.opcode]
 
@@ -230,17 +233,21 @@ class Configuration(BaseConfiguration):
 
     @property
     def has_active_frame(self) -> bool:
-        return bool(self.frame_stack)
+        try:
+            return bool(self.frame)
+        except AttributeError:
+            return False
 
     @property
     def active_label(self) -> Label:
-        return self.frame.control_stack.peek()
+        return self.frame.label
 
     @property
     def has_active_label(self) -> bool:
-        if not self.has_active_frame:
+        try:
+            return bool(self.frame.label)
+        except AttributeError:
             return False
-        return bool(self.frame.control_stack)
 
     @property
     def instructions(self) -> InstructionSequence:

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -389,7 +389,7 @@ class Configuration(BaseConfiguration):
         self._frame = frame
         self._frame_stack.push(frame)
         self._operand_stack = self._frame.active_operand_stack
-        self._instructions = self._frame.active_instructions
+        self._instructions = frame.active_instructions
 
     def pop_frame(self) -> Frame:
         if self.has_active_label:

--- a/wasm/execution/instructions.py
+++ b/wasm/execution/instructions.py
@@ -18,15 +18,10 @@ class InstructionSequence(Sequence):
     Stateful stream of instructions for web assembly execution.
     """
     _instructions: Tuple[BaseInstruction, ...]
-    current: BaseInstruction
 
     def __init__(self, instructions: Iterable[BaseInstruction]) -> None:
         self._instructions = tuple(instructions)
         self._idx = -1
-        try:
-            self.current = self._instructions[0]
-        except IndexError:
-            pass
 
     def __str__(self) -> str:
         return f"[{' > '.join((str(instr) for instr in self._instructions))}]"
@@ -40,9 +35,7 @@ class InstructionSequence(Sequence):
     def __next__(self) -> BaseInstruction:
         self._idx += 1
         try:
-            instruction = self._instructions[self._idx]
-            self.current = instruction
-            return instruction
+            return self._instructions[self._idx]
         except IndexError:
             raise StopIteration
 
@@ -76,8 +69,3 @@ class InstructionSequence(Sequence):
 
     def seek(self, idx: int) -> None:
         self._idx = idx - 1
-        try:
-            self.current = self._instructions[self._idx]
-        except IndexError:
-            if hasattr(self, 'current'):
-                del self.current

--- a/wasm/execution/stack.py
+++ b/wasm/execution/stack.py
@@ -69,7 +69,7 @@ class ControlStack(BaseStack[Label]):
     """
     A stack used for labels during Web Assembly execution
     """
-    def get_by_label_idx(self, key: LabelIdx) -> Label:
+    def get_label_by_idx(self, key: LabelIdx) -> Label:
         return self._stack[-1 * (key + 1)]
 
 

--- a/wasm/execution/stack.py
+++ b/wasm/execution/stack.py
@@ -84,6 +84,7 @@ class Frame:
     active_operand_stack: OperandStack
     arity: int
 
+    label: Label
     operand_stack: OperandStack
     control_stack: ControlStack
 
@@ -113,6 +114,7 @@ class Frame:
 
     def push_label(self, label: Label) -> None:
         self.control_stack.push(label)
+        self.label = label
         self.active_instructions = label.instructions
         self.active_operand_stack = label.operand_stack
 
@@ -120,9 +122,11 @@ class Frame:
         label = self.control_stack.pop()
         if self.control_stack:
             active_label = self.control_stack.peek()
+            self.label = active_label
             self.active_instructions = active_label.instructions
             self.active_operand_stack = active_label.operand_stack
         else:
+            del self.label
             self.active_instructions = self.instructions
             self.active_operand_stack = self.operand_stack
         return label
@@ -130,10 +134,6 @@ class Frame:
     @property
     def has_active_label(self) -> bool:
         return bool(self.control_stack)
-
-    @property
-    def label(self) -> Label:
-        return self.control_stack.peek()
 
 
 class FrameStack(BaseStack[Frame]):

--- a/wasm/logic/memory.py
+++ b/wasm/logic/memory.py
@@ -33,12 +33,12 @@ def load_op(config: Configuration) -> None:
     """
     Logic function for the various *LOAD* memory opcodes.
     """
-    instruction = cast(MemoryOp, config.instructions.current)
+    instruction = cast(MemoryOp, config.current_instruction)
     logger.debug("%s()", instruction.opcode.text)
 
     memarg = instruction.memarg
 
-    memory_address = config.frame.module.memory_addrs[0]
+    memory_address = config.frame_module.memory_addrs[0]
     mem = config.store.mems[memory_address]
 
     base_offset = config.pop_u32()
@@ -74,12 +74,12 @@ def store_op(config: Configuration) -> None:
     """
     Logic function for the various *STORE* memory opcodes.
     """
-    instruction = cast(MemoryOp, config.instructions.current)
+    instruction = cast(MemoryOp, config.current_instruction)
     logger.debug("%s()", instruction.opcode.text)
 
     memarg = instruction.memarg
 
-    memory_address = config.frame.module.memory_addrs[0]
+    memory_address = config.frame_module.memory_addrs[0]
     mem = config.store.mems[memory_address]
 
     value = config.pop_operand()
@@ -104,9 +104,9 @@ def memory_size_op(config: Configuration) -> None:
     """
     Logic function for the MEMORY_SIZE opcode
     """
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    logger.debug("%s()", config.current_instruction.opcode.text)
 
-    memory_address = config.frame.module.memory_addrs[0]
+    memory_address = config.frame_module.memory_addrs[0]
     mem = config.store.mems[memory_address]
     size = numpy.uint32(len(mem.data) // constants.PAGE_SIZE_64K)
     config.push_operand(size)
@@ -116,9 +116,9 @@ def memory_grow_op(config: Configuration) -> None:
     """
     Logic function for the MEMORY_GROW opcode
     """
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    logger.debug("%s()", config.current_instruction.opcode.text)
 
-    memory_address = config.frame.module.memory_addrs[0]
+    memory_address = config.frame_module.memory_addrs[0]
     mem = config.store.mems[memory_address]
     current_num_pages = mem.num_pages
     num_pages = config.pop_u32()

--- a/wasm/logic/numeric.py
+++ b/wasm/logic/numeric.py
@@ -52,7 +52,7 @@ def const_op(config: Configuration) -> None:
     """
     Common logic function for the various CONST opcodes.
     """
-    instruction = cast(TConst, config.instructions.current)
+    instruction = cast(TConst, config.current_instruction)
     logger.debug("%s(%s)", instruction.opcode.text, instruction)
 
     config.push_operand(instruction.value)
@@ -63,7 +63,7 @@ def ieqz_op(config: Configuration) -> None:
     Common logic function for the integer EQZ opcodes
     """
     value = config.pop_operand()
-    logger.debug("%s(%s)", config.instructions.current.opcode.text, value)
+    logger.debug("%s(%s)", config.current_instruction.opcode.text, value)
 
     if value == 0:
         config.push_operand(constants.U32_ONE)
@@ -79,7 +79,7 @@ def eq_op(config: Configuration) -> None:
     Common logic function for all EQ opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a == b:
         config.push_operand(constants.U32_ONE)
@@ -92,7 +92,7 @@ def ne_op(config: Configuration) -> None:
     Common logic function for all NE opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a == b:
         config.push_operand(constants.U32_ZERO)
@@ -108,7 +108,7 @@ def iltu_op(config: Configuration) -> None:
     Common logic function for the integer LTU opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a < b:
         config.push_operand(constants.U32_ONE)
@@ -121,7 +121,7 @@ def ileu_op(config: Configuration) -> None:
     Common logic function for the integer LEU opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a <= b:
         config.push_operand(constants.U32_ONE)
@@ -134,7 +134,7 @@ def igtu_op(config: Configuration) -> None:
     Common logic function for the integer GTU opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a > b:
         config.push_operand(constants.U32_ONE)
@@ -147,7 +147,7 @@ def igeu_op(config: Configuration) -> None:
     Common logic function for the integer GEU opcodes
     """
     b, a = config.pop2_operands()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if a >= b:
         config.push_operand(constants.U32_ONE)
@@ -162,7 +162,7 @@ def iXX_lts_op(config: Configuration) -> None:
     """
     Common logic function for the integer LTS opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
     b, a = config.pop2_u64()
     b_s = instruction.valtype.to_signed(b)
     a_s = instruction.valtype.to_signed(a)
@@ -178,7 +178,7 @@ def iXX_les_op(config: Configuration) -> None:
     """
     Common logic function for the integer LES opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
     b, a = config.pop2_u64()
     b_s = instruction.valtype.to_signed(b)
     a_s = instruction.valtype.to_signed(a)
@@ -194,7 +194,7 @@ def iXX_gts_op(config: Configuration) -> None:
     """
     Common logic function for the integer GTS opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
     b, a = config.pop2_u64()
     b_s = instruction.valtype.to_signed(b)
     a_s = instruction.valtype.to_signed(a)
@@ -210,7 +210,7 @@ def iXX_ges_op(config: Configuration) -> None:
     """
     Common logic function for the integer GES opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
     b, a = config.pop2_u64()
     b_s = instruction.valtype.to_signed(b)
     a_s = instruction.valtype.to_signed(a)
@@ -230,7 +230,7 @@ def iXX_add_op(config: Configuration) -> None:
     Common logic function for the integer ADD opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     with allow_overflow():
         config.push_operand(a + b)
@@ -241,7 +241,7 @@ def iXX_sub_op(config: Configuration) -> None:
     Common logic function for the integer SUB opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     with allow_overflow():
         config.push_operand(a - b)
@@ -255,7 +255,7 @@ def iXX_mul_op(config: Configuration) -> None:
     Common logic function for the integer MUL opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     with allow_overflow():
         config.push_operand(a * b)
@@ -269,7 +269,7 @@ def idivu_op(config: Configuration) -> None:
     Common logic function for the integer DIVU opcodes
     """
     b, a = config.pop2_u32()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if b == 0:
         raise Trap('DIVISION BY ZERO')
@@ -280,7 +280,7 @@ def iXX_divs_op(config: Configuration) -> None:
     """
     Common logic function for the integer DIVS opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a = config.pop2_u32()
 
     b_s = instruction.valtype.to_signed(b)
@@ -313,7 +313,7 @@ def iXX_clz_op(config: Configuration) -> None:
     """
     Common logic function for the integer CLZ opcodes
     """
-    instruction = cast(TestOp, config.instructions.current)
+    instruction = cast(TestOp, config.current_instruction)
     value = config.pop_u64()
     logger.debug("%s(%s)", instruction.opcode.text, value)
 
@@ -331,7 +331,7 @@ def iXX_ctz_op(config: Configuration) -> None:
     """
     Common logic function for the integer CTZ opcodes
     """
-    instruction = cast(TestOp, config.instructions.current)
+    instruction = cast(TestOp, config.current_instruction)
     value = config.pop_u64()
     logger.debug("%s(%s)", instruction.opcode.text, value)
 
@@ -350,7 +350,7 @@ def ipopcnt_op(config: Configuration) -> None:
     """
     Common logic function for the integer POPCNT opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
     value = config.pop_operand()
     logger.debug("%s(%s)", instruction.opcode.text, value)
 
@@ -368,7 +368,7 @@ def iremu_op(config: Configuration) -> None:
     Common logic function for the integer REMU opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     if b == 0:
         raise Trap('DIVISION BY ZERO')
@@ -380,7 +380,7 @@ def iXX_rems_op(config: Configuration) -> None:
     """
     Common logic function for the integer REMS opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a = config.pop2_u64()
     logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
 
@@ -404,7 +404,7 @@ def iand_op(config: Configuration) -> None:
     Common logic function for the integer AND opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     config.push_operand(a & b)
 
@@ -414,7 +414,7 @@ def ior_op(config: Configuration) -> None:
     Common logic function for the integer OR opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     config.push_operand(a | b)
 
@@ -424,7 +424,7 @@ def ixor_op(config: Configuration) -> None:
     Common logic function for the integer XOR opcodes
     """
     b, a = config.pop2_u64()
-    logger.debug("%s(%s, %s)", config.instructions.current.opcode.text, a, b)
+    logger.debug("%s(%s, %s)", config.current_instruction.opcode.text, a, b)
 
     config.push_operand(a ^ b)
 
@@ -436,7 +436,7 @@ def iXX_shl_op(config: Configuration) -> None:
     """
     Common logic function for the integer SHL opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a = config.pop2_u64()
     logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
 
@@ -450,7 +450,7 @@ def iXX_shr_sXX_op(config: Configuration) -> None:
     """
     Common logic function for the integer SHR opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a_raw = config.pop2_u64()
 
     if instruction.signed:
@@ -476,7 +476,7 @@ def iXX_rotl_op(config: Configuration) -> None:
     """
     Common logic function for the integer ROTL opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a = config.pop2_u64()
 
     logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
@@ -494,7 +494,7 @@ def iXX_rotr_op(config: Configuration) -> None:
     """
     Common logic function for the integer ROTR opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
     b, a = config.pop2_u64()
 
     logger.debug("%s(%s, %s)", instruction.opcode.text, a, b)
@@ -515,7 +515,7 @@ def flt_op(config: Configuration) -> None:
     """
     Common logic function for the float LT opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -543,7 +543,7 @@ def fgt_op(config: Configuration) -> None:
     """
     Common logic function for the float GT opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -571,7 +571,7 @@ def fle_op(config: Configuration) -> None:
     """
     Common logic function for the float LE opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -601,7 +601,7 @@ def fge_op(config: Configuration) -> None:
     """
     Common logic function for the float GT opcodes
     """
-    instruction = cast(RelOp, config.instructions.current)
+    instruction = cast(RelOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -634,7 +634,7 @@ def fabs_op(config: Configuration) -> None:
     """
     Common logic function for the float ABS opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     a = config.pop_f64()
 
@@ -688,7 +688,7 @@ def fneg_op(config: Configuration) -> None:
     """
     Common logic function for the float NEG opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -703,7 +703,7 @@ def fceil_op(config: Configuration) -> None:
     """
     Common logic function for the float CEIL opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -726,7 +726,7 @@ def ffloor_op(config: Configuration) -> None:
     """
     Common logic function for the float FLOOR opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -747,7 +747,7 @@ def ftrunc_op(config: Configuration) -> None:
     """
     Common logic function for the float TRUNC opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -771,7 +771,7 @@ def fnearest_op(config: Configuration) -> None:
     """
     Common logic function for the float NEAREST opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -794,7 +794,7 @@ def fsqrt_op(config: Configuration) -> None:
     """
     Common logic function for the float SQRT opcodes
     """
-    instruction = cast(UnOp, config.instructions.current)
+    instruction = cast(UnOp, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -867,7 +867,7 @@ def fadd_op(config: Configuration) -> None:
     """
     Common logic function for the float ADD opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -881,7 +881,7 @@ def fsub_op(config: Configuration) -> None:
     """
     Common logic function for the float SUB opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -904,7 +904,7 @@ def fmul_op(config: Configuration) -> None:
     """
     Common logic function for the float MUL opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -929,7 +929,7 @@ def fdiv_op(config: Configuration) -> None:
     """
     Common logic function for the float DIV opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -971,7 +971,7 @@ def fmin_op(config: Configuration) -> None:
     """
     Common logic function for the float MIN opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -995,7 +995,7 @@ def fmax_op(config: Configuration) -> None:
     """
     Common logic function for the float MAX opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -1022,7 +1022,7 @@ def fcopysign_op(config: Configuration) -> None:
     """
     Common logic function for the float COPYSIGN opcodes
     """
-    instruction = cast(BinOp, config.instructions.current)
+    instruction = cast(BinOp, config.current_instruction)
 
     b, a = config.pop2_f64()
 
@@ -1044,7 +1044,7 @@ def iwrap64_op(config: Configuration) -> None:
     """
     Logic function for the I32_WRAP_I64 opcode
     """
-    instruction = cast(Wrap, config.instructions.current)
+    instruction = cast(Wrap, config.current_instruction)
 
     value = config.pop_u64()
 
@@ -1058,7 +1058,7 @@ def iXX_trunc_usX_fXX_op(config: Configuration) -> None:
     Common logic function for the TRUNC opcodes which convert a float to an
     integer
     """
-    instruction = cast(Truncate, config.instructions.current)
+    instruction = cast(Truncate, config.current_instruction)
 
     value = config.pop_f32()
 
@@ -1096,7 +1096,7 @@ def i64extend_usX_op(config: Configuration) -> None:
     """
     Common logic function for the EXTEND opcodes
     """
-    instruction = cast(Extend, config.instructions.current)
+    instruction = cast(Extend, config.current_instruction)
 
     value = config.pop_u32()
 
@@ -1115,7 +1115,7 @@ def fXX_convert_usX_iXX_op(config: Configuration) -> None:
     """
     Common logic function for the CONVERT opcodes
     """
-    instruction = cast(Convert, config.instructions.current)
+    instruction = cast(Convert, config.current_instruction)
 
     base_value = config.pop_u64()
 
@@ -1133,7 +1133,7 @@ def f32demote_op(config: Configuration) -> None:
     """
     Logic function for the F32_DEMOTE_F64 opcode
     """
-    instruction = cast(Convert, config.instructions.current)
+    instruction = cast(Convert, config.current_instruction)
 
     value = config.pop_f64()
 
@@ -1146,7 +1146,7 @@ def f64promote_op(config: Configuration) -> None:
     """
     Logic function for the F64_PROMOTE_F32 opcode
     """
-    instruction = cast(Convert, config.instructions.current)
+    instruction = cast(Convert, config.current_instruction)
 
     value = config.pop_f32()
 
@@ -1165,7 +1165,7 @@ def XXX_reinterpret_XXX_op(config: Configuration) -> None:
     """
     Common logic function for the REINTERPRET opcodes
     """
-    instruction = cast(Convert, config.instructions.current)
+    instruction = cast(Convert, config.current_instruction)
 
     value = config.pop_f32()
 

--- a/wasm/logic/parametric.py
+++ b/wasm/logic/parametric.py
@@ -11,7 +11,7 @@ def drop_op(config: Configuration) -> None:
     """
     Logic functin for the DROP opcode.
     """
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    logger.debug("%s()", config.current_instruction.opcode.text)
 
     config.pop_operand()
 
@@ -20,7 +20,7 @@ def select_op(config: Configuration) -> None:
     """
     Logic functin for the SELECT opcode.
     """
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    logger.debug("%s()", config.current_instruction.opcode.text)
 
     a, b, c = config.pop3_operands()
 

--- a/wasm/logic/variable.py
+++ b/wasm/logic/variable.py
@@ -22,21 +22,21 @@ def set_local_op(config: Configuration) -> None:
     """
     Logic functin for the SET_LOCAL opcode.
     """
-    instruction = cast(LocalOp, config.instructions.current)
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    instruction = cast(LocalOp, config.current_instruction)
+    logger.debug("%s()", instruction.opcode.text)
 
     value = config.pop_operand()
-    config.frame.locals[instruction.local_idx] = value
+    config.frame_locals[instruction.local_idx] = value
 
 
 def get_local_op(config: Configuration) -> None:
     """
     Logic functin for the GET_LOCAL opcode.
     """
-    instruction = cast(LocalOp, config.instructions.current)
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    instruction = cast(LocalOp, config.current_instruction)
+    logger.debug("%s()", instruction.opcode.text)
 
-    value = config.frame.locals[instruction.local_idx]
+    value = config.frame_locals[instruction.local_idx]
     config.push_operand(value)
 
 
@@ -44,11 +44,11 @@ def tee_local_op(config: Configuration) -> None:
     """
     Logic functin for the TEE_LOCAL opcode.
     """
-    instruction = cast(LocalOp, config.instructions.current)
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    instruction = cast(LocalOp, config.current_instruction)
+    logger.debug("%s()", instruction.opcode.text)
 
     value = config.pop_operand()
-    config.frame.locals[instruction.local_idx] = value
+    config.frame_locals[instruction.local_idx] = value
     config.push_operand(value)
 
 
@@ -56,10 +56,10 @@ def get_global_op(config: Configuration) -> None:
     """
     Logic functin for the GET_GLOBAL opcode.
     """
-    instruction = cast(GlobalOp, config.instructions.current)
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    instruction = cast(GlobalOp, config.current_instruction)
+    logger.debug("%s()", instruction.opcode.text)
 
-    global_address = config.frame.module.global_addrs[instruction.global_idx]
+    global_address = config.frame_module.global_addrs[instruction.global_idx]
     global_ = config.store.globals[global_address]
     config.push_operand(global_.value)
 
@@ -68,10 +68,10 @@ def set_global_op(config: Configuration) -> None:
     """
     Logic functin for the SET_GLOBAL opcode.
     """
-    instruction = cast(GlobalOp, config.instructions.current)
-    logger.debug("%s()", config.instructions.current.opcode.text)
+    instruction = cast(GlobalOp, config.current_instruction)
+    logger.debug("%s()", instruction.opcode.text)
 
-    global_address = config.frame.module.global_addrs[instruction.global_idx]
+    global_address = config.frame_module.global_addrs[instruction.global_idx]
     global_ = config.store.globals[global_address]
     if global_.mut is not Mutability.var:
         raise Exception("Attempt to set immutable global")

--- a/wasm/parsers/sections.py
+++ b/wasm/parsers/sections.py
@@ -69,11 +69,11 @@ from .imports import (
 from .indices import (
     parse_type_idx,
 )
-from .integers import (
-    parse_u32,
-)
 from .memory import (
     parse_memory,
+)
+from .size import (
+    parse_size,
 )
 from .tables import (
     parse_table,
@@ -304,7 +304,7 @@ def _parse_sections(stream: IO[bytes]) -> Iterable[SECTION_TYPES]:
 
         seen_section_ids.add(section_id)
 
-        for empty_id, empty_section in _next_empty_section(section_id, empty_section_iter):
+        for _, empty_section in _next_empty_section(section_id, empty_section_iter):
             missing_section_ids.add(section_id)
             yield empty_section
 
@@ -331,7 +331,7 @@ def validate_section_length(parser_fn: Callable[[IO[bytes]], TReturn]
         # Note: Section parsers all operate under the assumption that their `stream`
         # contains **only** the bytes for the given section.  It follows that
         # successful parsing for any section **must** consume the full stream.
-        declared_size = parse_u32(stream)
+        declared_size = parse_size(stream)
         raw_section = stream.read(declared_size)
 
         if len(raw_section) != declared_size:

--- a/wasm/validation/control.py
+++ b/wasm/validation/control.py
@@ -100,7 +100,7 @@ def validate_br(instruction: Br, ctx: ExpressionContext) -> None:
     """
     ctx.control_stack.validate_label_idx(instruction.label_idx)
 
-    frame = ctx.control_stack.get_by_label_idx(instruction.label_idx)
+    frame = ctx.control_stack.get_label_by_idx(instruction.label_idx)
     expected_label_types = frame.label_types
 
     ctx.pop_operands_of_expected_types(expected_label_types)
@@ -113,7 +113,7 @@ def validate_br_if(instruction: BrIf, ctx: ExpressionContext) -> None:
     """
     ctx.control_stack.validate_label_idx(instruction.label_idx)
 
-    frame = ctx.control_stack.get_by_label_idx(instruction.label_idx)
+    frame = ctx.control_stack.get_label_by_idx(instruction.label_idx)
     label_types = frame.label_types
 
     ctx.pop_operand_and_assert_type(ValType.i32)
@@ -129,12 +129,12 @@ def validate_br_table(instruction: BrTable, ctx: ExpressionContext) -> None:
     """
     ctx.control_stack.validate_label_idx(instruction.default_idx)
 
-    frame = ctx.control_stack.get_by_label_idx(instruction.default_idx)
+    frame = ctx.control_stack.get_label_by_idx(instruction.default_idx)
     expected_label_types = frame.label_types
 
     for idx, label_idx in enumerate(instruction.label_indices):
         ctx.control_stack.validate_label_idx(label_idx)
-        label_frame = ctx.control_stack.get_by_label_idx(label_idx)
+        label_frame = ctx.control_stack.get_label_by_idx(label_idx)
 
         if label_frame.label_types != expected_label_types:
             raise ValidationError(

--- a/wasm/validation/stack.py
+++ b/wasm/validation/stack.py
@@ -20,7 +20,7 @@ class ControlStack(BaseStack[ControlFrame]):
     """
     Stack used during expression validation for control frames
     """
-    def get_by_label_idx(self, key: LabelIdx) -> ControlFrame:
+    def get_label_by_idx(self, key: LabelIdx) -> ControlFrame:
         return self._stack[-1 * (key + 1)]
 
     def validate_label_idx(self, label_idx: LabelIdx) -> None:


### PR DESCRIPTION
### What was wrong

Profiling showed that a **lot** of time was being spent 

- determining which operand stack and instruction sequence was active during execution.
- what the current instruction was
- what the current label was for a frame

This was due to these being implemented as property methods and them having to dig into other data structures.  Since these are accessed **alot** during execution, it seems to make sense to make some mutability trade-offs in this section of the code.

### How was it fixed

These values are now memoized at both the `Frame` and `Configuration` level as things are pushed and popped from the various stacks.

The following cleanups were also done:

- remove direct access to `Configuration` properties in most cases.
- remove un-used `Configuration` APIs
  - `config.active_label`
  - rename `get_by_label_idx` to `get_label_by_idx` because I have been consistently typing the later by instinct which indicates my initial naming was wrong.
- use a `memoryview` for reading memory sections to reduce number of object copies.
- change `MemoryInstance` to a normal object as `NamedTuple` no longer made sense with the following changes:
  - local cache of `len(data)`
- move `Exhaustion` error due to frame stack too large into `Configuration` API as it didn't feel appropriately placed within the control logic function code.
- fix error string when linking fails to use correct module name
- add ability to load directly from a file-like object on `Runtime` object (needed in ewasm)


![fox-attacking-chic_1655097a](https://user-images.githubusercontent.com/824194/53435557-4ff81400-39b6-11e9-9a8e-99b9089907ee.jpg)
