### PR TITLE
Rename result to from_valtype on instruction objects

### DIFF
--- a/wasm/instructions/numeric.py
+++ b/wasm/instructions/numeric.py
@@ -415,7 +415,7 @@ class TestOp(Interned):
 class Wrap(SimpleOp):
     opcode = BinaryOpcode.I32_WRAP_I64
     valtype = ValType.i32
-    result = ValType.i64
+    from_valtype = ValType.i64
 
 
 @register
@@ -423,11 +423,11 @@ class Truncate(Interned):
     def __init__(self,
                  opcode: BinaryOpcode,
                  valtype: ValType,
-                 result: ValType,
+                 from_valtype: ValType,
                  signed: bool) -> None:
         self.opcode = opcode
         self.valtype = valtype
-        self.result = result
+        self.from_valtype = from_valtype
         self.signed = signed
 
     def __str__(self) -> str:
@@ -460,11 +460,11 @@ class Extend(Interned):
     def __init__(self,
                  opcode: BinaryOpcode,
                  valtype: ValType,
-                 result: ValType,
+                 from_valtype: ValType,
                  signed: bool) -> None:
         self.opcode = opcode
         self.valtype = valtype
-        self.result = result
+        self.from_valtype = from_valtype
         self.signed = signed
 
     def __str__(self) -> str:
@@ -484,14 +484,14 @@ class Extend(Interned):
 class Demote(SimpleOp):
     opcode = BinaryOpcode.F32_DEMOTE_F64
     valtype = ValType.f32
-    result = ValType.f64
+    from_valtype = ValType.f64
 
 
 @register
 class Promote(SimpleOp):
     opcode = BinaryOpcode.F64_PROMOTE_F32
     valtype = ValType.f64
-    result = ValType.f32
+    from_valtype = ValType.f32
 
 
 @register
@@ -499,11 +499,11 @@ class Convert(Interned):
     def __init__(self,
                  opcode: BinaryOpcode,
                  valtype: ValType,
-                 result: ValType,
+                 from_valtype: ValType,
                  signed: bool) -> None:
         self.opcode = opcode
         self.valtype = valtype
-        self.result = result
+        self.from_valtype = from_valtype
         self.signed = signed
 
     def __str__(self) -> str:
@@ -536,10 +536,10 @@ class Reinterpret(Interned):
     def __init__(self,
                  opcode: BinaryOpcode,
                  valtype: ValType,
-                 result: ValType) -> None:
+                 from_valtype: ValType) -> None:
         self.opcode = opcode
         self.valtype = valtype
-        self.result = result
+        self.from_valtype = from_valtype
 
     def __str__(self) -> str:
         return self.opcode.text

--- a/wasm/main.py
+++ b/wasm/main.py
@@ -1249,7 +1249,7 @@ def spec_t2cvtopt1(config: Configuration) -> None:
 
     instruction = cast(T_t2cvt, config.instructions.current)
     t2 = instruction.valtype
-    t1 = instruction.result
+    t1 = instruction.from_valtype
     op = opcode2exec[instruction.opcode][1]
     c1 = config.pop_operand()
 

--- a/wasm/validation/numeric.py
+++ b/wasm/validation/numeric.py
@@ -106,12 +106,12 @@ def validate_extend(ctx: ExpressionContext) -> None:
 
 
 def validate_truncate(instruction: Truncate, ctx: ExpressionContext) -> None:
-    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.pop_operand_and_assert_type(instruction.from_valtype)
     ctx.operand_stack.push(instruction.valtype)
 
 
 def validate_convert(instruction: Convert, ctx: ExpressionContext) -> None:
-    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.pop_operand_and_assert_type(instruction.from_valtype)
     ctx.operand_stack.push(instruction.valtype)
 
 
@@ -126,5 +126,5 @@ def validate_demote(ctx: ExpressionContext) -> None:
 
 
 def validate_reinterpret(instruction: Reinterpret, ctx: ExpressionContext) -> None:
-    ctx.pop_operand_and_assert_type(instruction.result)
+    ctx.pop_operand_and_assert_type(instruction.from_valtype)
     ctx.operand_stack.push(instruction.valtype)


### PR DESCRIPTION
## What was wrong?

One of the fields on the numeric opcodes was named poorly.

## How was it fixed?

Changed the name to be `from_valtype` to ensure that it easier to know in the context of the conversion what the source type is.

#### Cute Animal Picture

![bbbbbbbbbbbbbb](https://user-images.githubusercontent.com/824194/52675895-80837c80-2ee5-11e9-8e50-7217bbc21df7.jpg)

