### PR TITLE
Add parse_size utility

### DIFF
--- a/wasm/parsers/byte.py
+++ b/wasm/parsers/byte.py
@@ -7,8 +7,8 @@ from wasm.typing import (
     UInt8,
 )
 
-from .integers import (
-    parse_u32,
+from .size import (
+    parse_size,
 )
 
 
@@ -22,7 +22,7 @@ def parse_single_byte(stream: IO[bytes]) -> UInt8:
 
 
 def parse_bytes(stream: IO[bytes]) -> bytes:
-    size = parse_u32(stream)
+    size = parse_size(stream)
     data = stream.read(size)
 
     if len(data) != size:

--- a/wasm/parsers/size.py
+++ b/wasm/parsers/size.py
@@ -1,4 +1,7 @@
-from typing import IO
+from typing import (
+    IO,
+    cast,
+)
 
 from .integers import (
     parse_u32,
@@ -7,4 +10,4 @@ from .integers import (
 
 def parse_size(stream: IO[bytes]) -> int:
     raw_size = parse_u32(stream)
-    return int(raw_size)
+    return cast(int, raw_size)

--- a/wasm/parsers/size.py
+++ b/wasm/parsers/size.py
@@ -1,0 +1,10 @@
+from typing import IO
+
+from .integers import (
+    parse_u32,
+)
+
+
+def parse_size(stream: IO[bytes]) -> int:
+    raw_size = parse_u32(stream)
+    return int(raw_size)

--- a/wasm/parsers/text.py
+++ b/wasm/parsers/text.py
@@ -5,13 +5,13 @@ from wasm.exceptions import (
     ParseError,
 )
 
-from .integers import (
-    parse_u32,
+from .size import (
+    parse_size,
 )
 
 
 def parse_text(stream: IO[bytes]) -> str:
-    encoded_name_length = parse_u32(stream)
+    encoded_name_length = parse_size(stream)
     encoded_name = stream.read(encoded_name_length)
 
     if len(encoded_name) != encoded_name_length:


### PR DESCRIPTION
## What was wrong?

Once the `numpy` stuff lands, `mypy` complains about using the numpy integer types in `stream.read()`.

## How was it fixed?

Added a `parse_size` parser that returns the value as a plain `int`

#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/52675959-b0328480-2ee5-11e9-9e54-2c7618158cb2.jpg)

