### PR TITLE
Lint setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ extras_require = {
 }
 
 extras_require['dev'] = (
-    extras_require['dev'] +
-    extras_require['test'] +
-    extras_require['lint'] +
-    extras_require['doc']
+    extras_require['dev']
+    + extras_require['test']  # noqa: W503
+    + extras_require['lint']  # noqa: W503
+    + extras_require['doc']  # noqa: W503
 )
 
 setup(


### PR DESCRIPTION
## What was wrong?

My linter was complaining about these lines

## How was it fixed?

Added `noqa` to ignore them.

#### Cute Animal Picture

![article-2100945-11bb571b000005dc-264_966x903](https://user-images.githubusercontent.com/824194/52675541-68f7c400-2ee4-11e9-8c22-340a75e86b8a.jpg)

