### PR TITLE
Cleanup unused APIs on Export type

### DIFF
--- a/wasm/datatypes/exports.py
+++ b/wasm/datatypes/exports.py
@@ -1,6 +1,7 @@
 from typing import (
     NamedTuple,
     Union,
+    cast,
 )
 
 from .addresses import (
@@ -78,13 +79,5 @@ class ExportInstance(NamedTuple):
         return isinstance(self.value, FunctionAddress)
 
     @property
-    def is_global(self):
-        return isinstance(self.value, GlobalAddress)
-
-    @property
-    def is_memory(self):
-        return isinstance(self.value, MemoryAddress)
-
-    @property
-    def is_table(self):
-        return isinstance(self.value, TableAddress)
+    def function_address(self) -> FunctionAddress:
+        return cast(FunctionAddress, self.value)


### PR DESCRIPTION
## What was wrong?

There were multiple property methods on the `Export` type which are not used (as measured by running code coverage)

## How was it fixed?

Removed them since they weren't needed.

#### Cute Animal Picture

![bird-w-flower-on-head](https://user-images.githubusercontent.com/824194/52675593-8c227380-2ee4-11e9-9ab7-e64c2520573c.jpg)

