### PR TITLE
Add new cli flags for easier spec test running

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,39 @@ If you are in a beta version, `make release bump=stage` will switch to a stable.
 
 To issue an unstable version when the current version is stable, specify the
 new version explicitly, like `make release bump="--new-version 4.0.0-alpha.1 devnum"`
+
+
+## Development and Testing
+
+The test suite in this library is run using `pytest`.
+
+```sh
+pytest tests/
+```
+
+Part of the test suite includes the *spec* tests from the official Web Assembly
+spec.  These are found under `./tests/spec`.
+
+It is often useful to view logging output when running tests.  This can be done with:
+
+```sh
+pytest tests/spec/ --log-cli-level=debug
+```
+
+When trying to diagnose a specific failure in a spec test it can be useful to
+run the tests in a branch that is currently passing, capture the logging
+output, and then compare it to the logging output of the test in the failing
+branch.  In order to make it easier to get the relevant logging output, you can
+use the flag `--stop-after-command-line=123` where `123` is the line for the
+failing command.  The full command would look something like:
+
+```sh
+pytest tests/spec/ --log-cli-level=debug --stop-after-command-line=123 -k f32.wast
+```
+
+This sets the logging output to `DEBUG` level, stops the test suite after it
+passes command line `123` and only runs the spec tests from the `f32.wast` spec
+test file.
+
+There are a few spec tests that take noticeably longer than the others.  You
+can omit these from the test run by adding the flag `--skip-slow-spec`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    parser.addoption("--skip-slow-spec", action="store_true", required=False)
+    parser.addoption("--stop-after-command-line", type=int, required=False)

--- a/tests/spec/test_spec.py
+++ b/tests/spec/test_spec.py
@@ -16,13 +16,16 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 def pytest_generate_tests(metafunc):
+    skip_slow_spec = metafunc.config.getoption('skip_slow_spec')
     generate_fixture_tests(
         metafunc=metafunc,
         fixtures_dir=FIXTURES_DIR,
+        skip_slow=skip_slow_spec,
     )
 
 
-def test_json_fixture(fixture_path):
+def test_json_fixture(fixture_path, pytestconfig):
+    stop_after_command_line = pytestconfig.getoption('stop_after_command_line')
     runtime = Runtime()
     # module "spectest" is imported from by many tests
     runtime.register_module(
@@ -34,4 +37,4 @@ def test_json_fixture(fixture_path):
         "test",
         instantiate_test_module(runtime.store),
     )
-    run_fixture_test(fixture_path, runtime)
+    run_fixture_test(fixture_path, runtime, stop_after_command_line)

--- a/wasm/tools/fixtures/generation.py
+++ b/wasm/tools/fixtures/generation.py
@@ -3,6 +3,8 @@ from pathlib import (
 )
 from typing import (
     Any,
+    Iterator,
+    Tuple,
 )
 
 from .loading import (
@@ -17,8 +19,28 @@ def idfn(fixture_path: Path) -> str:
     return str(fixture_path.resolve())
 
 
+SLOW_FIXTURES = {
+    'call.wast.json',
+    'call_indirect.wast.json',
+    'memory_grow.wast.json',
+    'skip-stack-guard-page.wast.json',
+}
+
+
+def mark_fixtures(all_fixture_paths: Tuple[Path, ...],
+                  skip_slow: bool) -> Iterator[Path]:
+    import pytest
+
+    for fixture_path in sorted(all_fixture_paths):
+        if skip_slow and fixture_path.name in SLOW_FIXTURES:
+            yield pytest.param(fixture_path, marks=pytest.mark.skip("slow"))
+        else:
+            yield fixture_path
+
+
 def generate_fixture_tests(metafunc: Any,
-                           fixtures_dir: Path) -> None:
+                           fixtures_dir: Path,
+                           skip_slow: bool) -> None:
     """
     Helper function for use with `pytest_generate_tests` to generate fixture tests.
 
@@ -26,7 +48,10 @@ def generate_fixture_tests(metafunc: Any,
     - `fixtures_dir` is the base path that fixture files will be collected from.
     """
     if 'fixture_path' in metafunc.fixturenames:
-        all_fixture_paths = tuple(sorted(find_json_fixture_files(fixtures_dir)))
+        all_fixture_paths = tuple(mark_fixtures(
+            all_fixture_paths=find_json_fixture_files(fixtures_dir),
+            skip_slow=skip_slow,
+        ))
         if len(all_fixture_paths) == 0:
             raise Exception("Invariant: found zero fixtures")
 

--- a/wasm/tools/fixtures/runner.py
+++ b/wasm/tools/fixtures/runner.py
@@ -432,7 +432,9 @@ SKIP_COMMANDS: Dict[str, Dict[int, Type[Exception]]] = {
 }
 
 
-def run_fixture_test(fixture_path: Path, runtime: Runtime) -> None:
+def run_fixture_test(fixture_path: Path,
+                     runtime: Runtime,
+                     stop_after: int = None) -> None:
     with fixture_path.open('r') as fixture_file:
         raw_fixture = json.load(fixture_file)
 
@@ -460,5 +462,8 @@ def run_fixture_test(fixture_path: Path, runtime: Runtime) -> None:
             if result:
                 module = result
         logger.debug("Finished command: line=%d  type=%s", command.line, str(type(command)))
+
+        if stop_after is not None and command.line >= stop_after:
+            break
 
     logger.debug("Finished test fixture: %s", fixture.file_path.name)


### PR DESCRIPTION
## What was wrong?

When debugging I got frustrated with 1) inability to skip the slowest tests and 2) having to inject custom code to stop the test run after a specific command line.

## How was it fixed?

Added two new CLI flags that can be used during test runs

- `--stop-after-command-line=<number>`
- `--skip-slow-spec`

#### Cute Animal Picture

![4xrbfsw](https://user-images.githubusercontent.com/824194/52675701-ddcafe00-2ee4-11e9-8612-39f8208707ea.jpg)

