### PR TITLE
Enable the assert NAN tests and get them passing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ extras_require = {
     ],
     'lint': [
         "flake8==3.6.0",
-        "isort>=4.2.15,<5",
+        "isort>=4.3.9,<5",
         "mypy==0.660",
     ],
     'doc': [

--- a/stubs/numpy.py
+++ b/stubs/numpy.py
@@ -30,6 +30,8 @@ def seterr(all: str = None,
 
 
 class __base_dtype:
+    data: memoryview
+
     def tobytes(self) -> bytes:
         ...
 
@@ -134,7 +136,7 @@ inf: float = ...
 nan: float = ...
 
 
-def frombuffer(buffer: bytes, type_: Type[T]) -> Tuple[T, ...]:
+def frombuffer(buffer: Union[bytes, memoryview, bytearray], type_: Type[T]) -> Tuple[T, ...]:
     ...
 
 

--- a/tests/core/float-utils/test_float_utils.py
+++ b/tests/core/float-utils/test_float_utils.py
@@ -1,0 +1,76 @@
+import numpy
+import pytest
+
+from wasm import (
+    constants,
+)
+from wasm._utils.float import (
+    compose_float32,
+    compose_float64,
+    decompose_float,
+    is_arithmetic_nan,
+    is_canonical_nan,
+)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (numpy.float32('nan'), (0, 2**constants.F32_EXPON - 1, constants.F32_CANON_N)),
+    ),
+)
+def test_decompose_float(value, expected):
+    e_sign, e_exponent, e_mantissa = expected
+    a_sign, a_exponent, a_mantissa = decompose_float(value)
+
+    assert a_sign == e_sign
+    assert a_exponent == e_exponent
+    assert a_mantissa == e_mantissa
+
+
+F32_C_SIGN, F32_C_EXPONENT, F32_C_MANTISSA = decompose_float(constants.F32_CANON_NAN)
+F64_C_SIGN, F64_C_EXPONENT, F64_C_MANTISSA = decompose_float(constants.F64_CANON_NAN)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (constants.F32_CANON_NAN, True),
+        (constants.F64_CANON_NAN, True),
+        (compose_float32(F32_C_SIGN, F32_C_EXPONENT, F32_C_MANTISSA + 1), False),
+        (compose_float64(F64_C_SIGN, F64_C_EXPONENT, F64_C_MANTISSA + 1), False),
+        (compose_float32(F32_C_SIGN, F32_C_EXPONENT, F32_C_MANTISSA - 1), False),
+        (compose_float64(F64_C_SIGN, F64_C_EXPONENT, F64_C_MANTISSA - 1), False),
+    ),
+)
+def test_is_canonical_nan(value, expected):
+    actual = is_canonical_nan(value)
+    if actual is not expected:
+        sign, exponent, mantissa = decompose_float(value)
+
+        raise AssertionError(
+            f"NAN is not canonical: sign:{int(sign)}  exponent:{int(exponent)}  "
+            f"mantissa:{int(mantissa)}"
+        )
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (constants.F32_CANON_NAN, True),
+        (constants.F64_CANON_NAN, True),
+        (compose_float32(F32_C_SIGN, F32_C_EXPONENT, F32_C_MANTISSA + 1), True),
+        (compose_float64(F64_C_SIGN, F64_C_EXPONENT, F64_C_MANTISSA + 1), True),
+        (compose_float32(F32_C_SIGN, F32_C_EXPONENT, F32_C_MANTISSA - 1), False),
+        (compose_float64(F64_C_SIGN, F64_C_EXPONENT, F64_C_MANTISSA - 1), False),
+    ),
+)
+def test_is_arithmetic_nan(value, expected):
+    actual = is_arithmetic_nan(value)
+    if actual is not expected:
+        sign, exponent, mantissa = decompose_float(value)
+
+        raise AssertionError(
+            f"NAN is not arithmetic: sign:{int(sign)}  exponent:{int(exponent)}  "
+            f"mantissa:{int(mantissa)}"
+        )

--- a/wasm/_utils/float.py
+++ b/wasm/_utils/float.py
@@ -1,0 +1,116 @@
+from typing import (
+    Any,
+    Tuple,
+)
+
+import numpy
+
+from wasm import (
+    constants,
+)
+from wasm.typing import (
+    AnyFloat,
+    AnyUnsigned,
+)
+
+# the mantissa bits
+MANTISSA_64_MASK = numpy.uint64(2**constants.F64_SIGNIF - 1)
+MANTISSA_32_MASK = numpy.uint32(2**constants.F32_SIGNIF - 1)
+
+# the expon bits
+EXPONENT_64_SHIFT = 64 - 1 - constants.F64_EXPON
+EXPONENT_32_SHIFT = 32 - 1 - constants.F32_EXPON
+EXPONENT_64_MASK = numpy.uint64(2**constants.F64_EXPON - 1 << EXPONENT_64_SHIFT)
+EXPONENT_32_MASK = numpy.uint32(2**constants.F32_EXPON - 1 << EXPONENT_32_SHIFT)
+
+# most significant bit
+SIGN_64_MASK = numpy.uint64(2**63)
+SIGN_32_MASK = numpy.uint32(2**31)
+
+_CHECK_64_AND_MASK = MANTISSA_64_MASK & EXPONENT_64_MASK & SIGN_64_MASK
+_CHECK_32_AND_MASK = MANTISSA_32_MASK & EXPONENT_32_MASK & SIGN_32_MASK
+_CHECK_64_OR_MASK = MANTISSA_64_MASK | EXPONENT_64_MASK | SIGN_64_MASK
+_CHECK_32_OR_MASK = MANTISSA_32_MASK | EXPONENT_32_MASK | SIGN_32_MASK
+
+
+assert _CHECK_64_AND_MASK == 0
+assert _CHECK_32_AND_MASK == 0
+assert _CHECK_64_OR_MASK == numpy.uint64(2**64 - 1)
+assert _CHECK_32_OR_MASK == numpy.uint32(2**32 - 1)
+
+
+def _decompose_float32(value: numpy.float32) -> Tuple[numpy.uint32, numpy.uint32, numpy.uint32]:
+    as_uint32 = numpy.frombuffer(value.data, numpy.uint32)[0]
+    sign = numpy.uint32(bool(as_uint32 & SIGN_32_MASK))
+    exponent = numpy.uint32(int(as_uint32 & EXPONENT_32_MASK) >> EXPONENT_32_SHIFT)
+    mantissa = as_uint32 & MANTISSA_32_MASK
+
+    return (sign, exponent, mantissa)
+
+
+def _decompose_float64(value: numpy.float64) -> Tuple[numpy.uint64, numpy.uint64, numpy.uint64]:
+    as_uint64 = numpy.frombuffer(value.data, numpy.uint64)[0]
+    sign = numpy.uint64(bool(as_uint64 & SIGN_64_MASK))
+    exponent = numpy.uint64(int(as_uint64 & EXPONENT_64_MASK) >> EXPONENT_64_SHIFT)
+    mantissa = as_uint64 & MANTISSA_64_MASK
+
+    return (sign, exponent, mantissa)
+
+
+def decompose_float(value: AnyFloat,
+                    ) -> Tuple[AnyUnsigned, AnyUnsigned, AnyUnsigned]:
+    if isinstance(value, numpy.float64):
+        return _decompose_float64(value)
+    elif isinstance(value, numpy.float32):
+        return _decompose_float32(value)
+    else:
+        raise TypeError(f"Invalid type: {type(value)}")
+
+
+def compose_float64(sign: AnyUnsigned,
+                    exponent: AnyUnsigned,
+                    mantissa: AnyUnsigned) -> numpy.float64:
+    as_uint64 = numpy.uint64(
+        (int(sign) << 63) | (int(exponent) << EXPONENT_64_SHIFT) | int(mantissa)
+    )
+    return numpy.frombuffer(as_uint64.data, numpy.float64)[0]
+
+
+def compose_float32(sign: AnyUnsigned,
+                    exponent: AnyUnsigned,
+                    mantissa: AnyUnsigned) -> numpy.float32:
+    as_uint32 = numpy.uint32(
+        (int(sign) << 32) | (int(exponent) << EXPONENT_32_SHIFT) | int(mantissa)
+    )
+    return numpy.frombuffer(as_uint32.data, numpy.float32)[0]
+
+
+def is_canonical_nan(value: Any) -> bool:
+    _, _, mantissa = decompose_float(value)
+
+    if not numpy.isnan(value):
+        return False
+    elif isinstance(value, numpy.float64):
+        return bool(mantissa == constants.F64_CANON_N)
+    elif isinstance(value, numpy.float32):
+        return bool(mantissa == constants.F32_CANON_N)
+    else:
+        raise TypeError(f"Invalid type: {type(value)}")
+
+
+# runtime check since the actual value *might* differ on different platforms.
+assert is_canonical_nan(constants.F32_CANON_NAN)
+assert is_canonical_nan(constants.F64_CANON_NAN)
+
+
+def is_arithmetic_nan(value: Any) -> bool:
+    _, _, mantissa = decompose_float(value)
+
+    if not numpy.isnan(value):
+        return False
+    elif isinstance(value, numpy.float64):
+        return bool(mantissa >= constants.F64_CANON_N)
+    elif isinstance(value, numpy.float32):
+        return bool(mantissa >= constants.F32_CANON_N)
+    else:
+        raise TypeError(f"Invalid type: {type(value)}")

--- a/wasm/constants.py
+++ b/wasm/constants.py
@@ -67,3 +67,17 @@ BYTE_SIZE = numpy.uint8(8)
 # Interned values for u32 zero and one
 U32_ZERO = numpy.uint32(0)
 U32_ONE = numpy.uint32(1)
+
+# NAN stuff
+# https://webassembly.github.io/spec/core/bikeshed/index.html#floating-point%E2%91%A0
+F64_SIGNIF = 52
+F32_SIGNIF = 23
+
+F64_EXPON = 11
+F32_EXPON = 8
+
+F32_CANON_N = numpy.uint32(2**(F32_SIGNIF - 1))
+F64_CANON_N = numpy.uint64(2**(F64_SIGNIF - 1))
+
+F32_CANON_NAN = numpy.float32('nan')
+F64_CANON_NAN = numpy.float64('nan')

--- a/wasm/datatypes/__init__.py
+++ b/wasm/datatypes/__init__.py
@@ -87,5 +87,4 @@ from .valtype import (  # noqa: F401
     ValType,
 )
 
-
 BaseFunctionInstance.register(FunctionInstance)

--- a/wasm/datatypes/valtype.py
+++ b/wasm/datatypes/valtype.py
@@ -14,9 +14,9 @@ from wasm.exceptions import (
     ValidationError,
 )
 from wasm.typing import (
-    AnyFloat,
-    AnyUnsigned,
+    Float,
     TValue,
+    UnsignedInt,
 )
 
 from .bit_size import (
@@ -196,7 +196,7 @@ class ValType(enum.Enum):
         else:
             raise TypeError(f"`-1` not defined for type {self}")
 
-    def to_signed(self, value: AnyUnsigned) -> AnySignedInteger:
+    def to_signed(self, value: UnsignedInt) -> AnySignedInteger:
         if self is self.i64:
             return numpy.int64(value)
         elif self is self.i32:
@@ -221,7 +221,7 @@ class ValType(enum.Enum):
         else:
             raise TypeError(f"Cannot convert {self} to unsigned integer")
 
-    def to_float(self, value: AnyInteger) -> AnyFloat:
+    def to_float(self, value: AnyInteger) -> Float:
         if self is self.f64:
             return numpy.float64(value)
         elif self is self.f32:
@@ -274,7 +274,7 @@ class ValType(enum.Enum):
         else:
             raise TypeError(f"Cannot unpack value of type {self}")
 
-    def unpack_float_bytes(self, raw_bytes: bytes) -> AnyFloat:
+    def unpack_float_bytes(self, raw_bytes: bytes) -> Float:
         if self is self.f64:
             return numpy.frombuffer(raw_bytes, numpy.float64)[0]
         elif self is self.f32:
@@ -283,28 +283,28 @@ class ValType(enum.Enum):
             raise TypeError(f"Cannot unpack value of type {self}")
 
     @property
-    def nan(self) -> AnyFloat:
+    def nan(self) -> Float:
         if self.is_float_type:
             return self.value('nan')
         else:
             raise TypeError(f"`nan` not defined for type {self}")
 
     @property
-    def negnan(self) -> AnyFloat:
+    def negnan(self) -> Float:
         if self.is_float_type:
             return self.value('-nan')
         else:
             raise TypeError(f"`-nan` not defined for type {self}")
 
     @property
-    def inf(self) -> AnyFloat:
+    def inf(self) -> Float:
         if self.is_float_type:
             return self.value('inf')
         else:
             raise TypeError(f"`inf` not defined for type {self}")
 
     @property
-    def neginf(self) -> AnyFloat:
+    def neginf(self) -> Float:
         if self.is_float_type:
             return self.value('-inf')
         else:

--- a/wasm/execution/__init__.py
+++ b/wasm/execution/__init__.py
@@ -9,9 +9,9 @@ from .runtime import (  # noqa: F401
 )
 from .stack import (  # noqa: F401
     BaseStack,
+    ControlStack,
     Frame,
     FrameStack,
     Label,
-    ControlStack,
     OperandStack,
 )

--- a/wasm/instructions/__init__.py
+++ b/wasm/instructions/__init__.py
@@ -52,7 +52,6 @@ from .variable import (  # noqa: F401
     LocalOp,
 )
 
-
 Instruction = Union[
     BaseInstruction,
     I32Const, I64Const,

--- a/wasm/logic/__init__.py
+++ b/wasm/logic/__init__.py
@@ -1,18 +1,20 @@
 from typing import (
     TYPE_CHECKING,
-    Dict,
     Callable,
+    Dict,
 )
 
 from wasm.opcodes import (
     BinaryOpcode,
 )
 
-from . import control
-from . import memory
-from . import numeric
-from . import parametric
-from . import variable
+from . import (
+    control,
+    memory,
+    numeric,
+    parametric,
+    variable,
+)
 
 if TYPE_CHECKING:
     from wasm.execution import (  # noqa:

--- a/wasm/logic/numeric.py
+++ b/wasm/logic/numeric.py
@@ -40,7 +40,7 @@ from wasm.instructions import (
     Wrap,
 )
 from wasm.typing import (
-    AnyFloat,
+    Float,
 )
 
 logger = logging.getLogger('wasm.logic.numeric')
@@ -655,7 +655,7 @@ def fabs_op(config: Configuration) -> None:
 FLOAT_SIGN_MASK = 0b10000000
 
 
-def _is_negative(value: AnyFloat) -> bool:
+def _is_negative(value: Float) -> bool:
     """
     Helper function which returns a boolean indicating if the floating point
     value is considered negative as determined by checking the value of the
@@ -664,7 +664,7 @@ def _is_negative(value: AnyFloat) -> bool:
     return bool(value.tobytes()[-1] & FLOAT_SIGN_MASK)
 
 
-TFloat = TypeVar('TFloat', bound=AnyFloat)
+TFloat = TypeVar('TFloat', bound=Float)
 
 
 def _negate_float(value: TFloat) -> TFloat:
@@ -1154,10 +1154,8 @@ def f64promote_op(config: Configuration) -> None:
 
     if numpy.isnan(value):
         if _is_negative(value):
-            logger.info('NEGATIVE')
             config.push_operand(numpy.float64('-nan'))
         else:
-            logger.info('POSITIVE')
             config.push_operand(numpy.float64('nan'))
     else:
         config.push_operand(numpy.float64(value))

--- a/wasm/tools/__init__.py
+++ b/wasm/tools/__init__.py
@@ -1,6 +1,6 @@
 from .fixtures import (  # noqa: F401
+    generate_fixture_tests,
     instantiate_spectest_module,
     instantiate_test_module,
     run_fixture_test,
-    generate_fixture_tests,
 )

--- a/wasm/tools/fixtures/__init__.py
+++ b/wasm/tools/fixtures/__init__.py
@@ -1,6 +1,10 @@
+from .generation import (  # noqa: F401
+    generate_fixture_tests,
+)
 from .modules import (  # noqa: F401
     instantiate_spectest_module,
     instantiate_test_module,
 )
-from .runner import run_fixture_test  # noqa: F401
-from .generation import generate_fixture_tests  # noqa: F401
+from .runner import (  # noqa: F401
+    run_fixture_test,
+)

--- a/wasm/tools/fixtures/datatypes.py
+++ b/wasm/tools/fixtures/datatypes.py
@@ -5,6 +5,7 @@ from typing import (
     NamedTuple,
     Optional,
     Tuple,
+    Type,
     Union,
 )
 
@@ -27,9 +28,17 @@ class Argument(NamedTuple):
     value: TValue
 
 
+class arithmetic_nan:
+    pass
+
+
+class canonical_nan:
+    pass
+
+
 class Expected(NamedTuple):
     valtype: ValType
-    value: Union[None, TValue]
+    value: Union[None, TValue, Type[arithmetic_nan], Type[canonical_nan]]
 
 
 class Action(NamedTuple):

--- a/wasm/typing.py
+++ b/wasm/typing.py
@@ -5,5 +5,5 @@ from typing import (
 import numpy
 
 TValue = Union[numpy.uint32, numpy.uint64, numpy.float32, numpy.float64]
-AnyUnsigned = Union[numpy.uint32, numpy.uint64]
-AnyFloat = Union[numpy.float32, numpy.float64]
+UnsignedInt = Union[numpy.uint32, numpy.uint64]
+Float = Union[numpy.float32, numpy.float64]


### PR DESCRIPTION
fixes #94 

## What was wrong?

There were still some spec tests being skiped, specifically the ones that do assertions about returned NAN values.

## How was it fixed?

Enabled the tests and fixed the logic function implementations so that they passed.

#### Cute Animal Picture

![animal-animals-babies-bird-birds-cute-favim com-40474](https://user-images.githubusercontent.com/824194/52822039-dbe07680-306d-11e9-8df9-579b33911b41.jpg)

