### PR TITLE
Add vendored to tuple decorator

### DIFF
--- a/wasm/_utils/decorators.py
+++ b/wasm/_utils/decorators.py
@@ -1,0 +1,16 @@
+import functools
+from typing import (
+    Callable,
+    Iterable,
+    Tuple,
+    TypeVar,
+)
+
+T = TypeVar('T')
+
+
+def to_tuple(fn: Callable[..., Iterable[T]]) -> Callable[..., Tuple[T, ...]]:
+    @functools.wraps(fn)
+    def inner(*args, **kwargs) -> Tuple[T, ...]:  # type: ignore
+        return tuple(fn(*args, **kwargs))
+    return inner

--- a/wasm/datatypes/store.py
+++ b/wasm/datatypes/store.py
@@ -11,6 +11,9 @@ import numpy
 from wasm import (
     constants,
 )
+from wasm._utils.decorators import (
+    to_tuple,
+)
 from wasm.exceptions import (
     ValidationError,
 )
@@ -63,6 +66,7 @@ TAddress = Union[FunctionAddress, GlobalAddress, MemoryAddress, TableAddress]
 TExtern = Union[FunctionType, TableType, MemoryType, GlobalType]
 
 
+@to_tuple
 def _collate_exports(exports: Tuple[Export, ...],
                      function_addresses: Tuple[FunctionAddress, ...],
                      table_addresses: Tuple[TableAddress, ...],
@@ -243,13 +247,13 @@ class Store:
         memory_addresses = MemoryAddress.filter(all_import_addresses) + module_memory_addresses
         global_addresses = GlobalAddress.filter(all_import_addresses) + module_globals_addresses
 
-        exports = tuple(_collate_exports(
+        exports = _collate_exports(
             exports=module.exports,
             function_addresses=function_addresses,
             table_addresses=table_addresses,
             memory_addresses=memory_addresses,
             global_addresses=global_addresses,
-        ))
+        )
 
         module_instance = ModuleInstance(
             types=module.types,

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -1,10 +1,12 @@
 from typing import (
     IO,
     Iterable,
-    Tuple,
     cast,
 )
 
+from wasm._utils.decorators import (
+    to_tuple,
+)
 from wasm._utils.toolz import (
     partitionby,
 )
@@ -90,14 +92,11 @@ def parse_block_instruction(stream: IO[bytes]) -> Block:
     return Block(result_type, instructions)
 
 
-def parse_inner_block_instructions(stream: IO[bytes]) -> Tuple[BaseInstruction, ...]:
+@to_tuple
+def parse_inner_block_instructions(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     """
     Helper to parse the instruction sequence for a BLOCK instruction
     """
-    return tuple(_parse_inner_block_instructions(stream))
-
-
-def _parse_inner_block_instructions(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     # recursive parsing
     from wasm.parsers.instructions import parse_instruction  # noqa: F401
 

--- a/wasm/parsers/expressions.py
+++ b/wasm/parsers/expressions.py
@@ -1,10 +1,12 @@
 from typing import (
     IO,
     Iterable,
-    Tuple,
     cast,
 )
 
+from wasm._utils.decorators import (
+    to_tuple,
+)
 from wasm.instructions import (
     BaseInstruction,
 )
@@ -17,14 +19,11 @@ from .instructions import (
 )
 
 
-def parse_expression(stream: IO[bytes]) -> Tuple[BaseInstruction, ...]:
+@to_tuple
+def parse_expression(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     """
     Helper for parsing a sequence of instructions
     """
-    return tuple(_parse_expression(stream))
-
-
-def _parse_expression(stream: IO[bytes]) -> Iterable[BaseInstruction]:
     while True:
         instruction = cast(BaseInstruction, parse_instruction(stream))
 

--- a/wasm/parsers/leb128.py
+++ b/wasm/parsers/leb128.py
@@ -7,6 +7,9 @@ from typing import (
     Iterable,
 )
 
+from wasm._utils.decorators import (
+    to_tuple,
+)
 from wasm.exceptions import (
     ParseError,
 )
@@ -55,6 +58,7 @@ def parse_unsigned_leb128(stream: IO[bytes]) -> int:
 SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
 
 
+@to_tuple
 def _parse_unsigned_leb128(stream: IO[bytes]) -> Iterable[int]:
     for shift in itertools.count(0, 7):
         if shift > SHIFT_64_BIT_MAX:

--- a/wasm/parsers/vector.py
+++ b/wasm/parsers/vector.py
@@ -8,6 +8,9 @@ from typing import (
 
 import numpy
 
+from wasm._utils.decorators import (
+    to_tuple,
+)
 from wasm.exceptions import (
     ParseError,
 )
@@ -32,6 +35,7 @@ def parse_vector(sub_parser: Callable[[IO[bytes]], TItem],
         raise ParseError(f"Error parsing vector: {err}") from err
 
 
+@to_tuple
 def _parse_vector(sub_parser: Callable[[IO[bytes]], TItem],
                   vector_size: numpy.uint32,
                   stream: IO[bytes],

--- a/wasm/tools/fixtures/generation.py
+++ b/wasm/tools/fixtures/generation.py
@@ -3,8 +3,12 @@ from pathlib import (
 )
 from typing import (
     Any,
-    Iterator,
+    Iterable,
     Tuple,
+)
+
+from wasm._utils.decorators import (
+    to_tuple,
 )
 
 from .loading import (
@@ -27,8 +31,9 @@ SLOW_FIXTURES = {
 }
 
 
+@to_tuple
 def mark_fixtures(all_fixture_paths: Tuple[Path, ...],
-                  skip_slow: bool) -> Iterator[Path]:
+                  skip_slow: bool) -> Iterable[Path]:
     import pytest
 
     for fixture_path in sorted(all_fixture_paths):
@@ -48,10 +53,10 @@ def generate_fixture_tests(metafunc: Any,
     - `fixtures_dir` is the base path that fixture files will be collected from.
     """
     if 'fixture_path' in metafunc.fixturenames:
-        all_fixture_paths = tuple(mark_fixtures(
+        all_fixture_paths = mark_fixtures(
             all_fixture_paths=find_json_fixture_files(fixtures_dir),
             skip_slow=skip_slow,
-        ))
+        )
         if len(all_fixture_paths) == 0:
             raise Exception("Invariant: found zero fixtures")
 


### PR DESCRIPTION
fixes #98 

fixes #95 

builds on #99 

## What was wrong?

The `to_tuple` pattern is more robust and requires less boilerplate.

## How was it fixed?

Vendored an implementation of `to_tuple` and converted the various functions to use the decorator.

#### Cute Animal Picture

![bob-golden-retriever-sao-paulo-131](https://user-images.githubusercontent.com/824194/52833864-30024f80-309c-11e9-861f-fc63abaa66d7.jpg)

