### PR TITLE
Use dtype data property over tobytes method when possible

### DIFF
--- a/wasm/datatypes/valtype.py
+++ b/wasm/datatypes/valtype.py
@@ -260,7 +260,7 @@ class ValType(enum.Enum):
         else:
             raise TypeError(f"Cannot convert {self} to unsigned integer")
 
-    def unpack_int_bytes(self, raw_bytes: bytes, signed: bool) -> AnyInteger:
+    def unpack_int_bytes(self, raw_bytes: Union[bytes, memoryview], signed: bool) -> AnyInteger:
         if self is self.i64:
             if signed:
                 return numpy.frombuffer(raw_bytes, numpy.int64)[0]
@@ -274,7 +274,7 @@ class ValType(enum.Enum):
         else:
             raise TypeError(f"Cannot unpack value of type {self}")
 
-    def unpack_float_bytes(self, raw_bytes: bytes) -> Float:
+    def unpack_float_bytes(self, raw_bytes: Union[bytes, memoryview]) -> Float:
         if self is self.f64:
             return numpy.frombuffer(raw_bytes, numpy.float64)[0]
         elif self is self.f32:

--- a/wasm/logic/numeric.py
+++ b/wasm/logic/numeric.py
@@ -1171,4 +1171,4 @@ def XXX_reinterpret_XXX_op(config: Configuration) -> None:
 
     logger.debug("%s(%s)", instruction.opcode.text, value)
 
-    config.push_operand(numpy.frombuffer(value.tobytes(), instruction.valtype.value)[0])
+    config.push_operand(numpy.frombuffer(value.data, instruction.valtype.value)[0])

--- a/wasm/tools/fixtures/normalizers.py
+++ b/wasm/tools/fixtures/normalizers.py
@@ -73,7 +73,7 @@ def _normalize_raw_value(valtype: ValType, raw_value: int) -> TValue:
     if valtype.is_integer_type:
         return valtype.value(raw_value)
     elif valtype.is_float_type:
-        return valtype.unpack_float_bytes(numpy.uint64(raw_value).tobytes())
+        return valtype.unpack_float_bytes(numpy.uint64(raw_value).data)
     else:
         raise Exception(f"Unhandled type: {valtype} | value: {raw_value}")
 


### PR DESCRIPTION
fixes #100 

builds on #99

## What was wrong?

We were incurring an extra object allocation by using `dtype.tobytes()` in places where we could have been directly using the `dtype.data` property.

## How was it fixed?

Converted to use the `.data` property when possible.

#### Cute Animal Picture

![3ec499603ef8c7e43ff050bb302f543e](https://user-images.githubusercontent.com/824194/52868464-a89af780-3100-11e9-83d7-01273a0debf1.jpg)

