### PR TITLE
Add web assemply spec as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ htmlcov/**
 
 # CProfile
 prof/**
+
+# WASM Spec submodule
+./spec/**

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = git@github.com:WebAssembly/spec.git


### PR DESCRIPTION
## What was wrong?

To implement #53 we'll need the web assemply spec as a submodule.  Switching back and forth from the branch results in having to be careful not to commit the `./spec` dir since it's not present on master.  Also, once `S-expression` based parsing is implemented we'll probably ditch `tests/spec/fixtures` in favor of pulling directly from the canonical test vectors (and thus being able to easily update to upstream changes which currently is hard)

## How was it fixed?

Added https://github.com/WebAssembly/spec/ as a submodule under `./spec`

#### Cute Animal Picture

![two-pandas-hug-on-tree](https://user-images.githubusercontent.com/824194/52879929-ce82c500-311d-11e9-93f6-b46ef1e1ae98.jpg)

