### PR TITLE
fix WebAssembly spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Docs build](https://readthedocs.org/projects/py-wasm/badge/?version=latest)](http://py-wasm.readthedocs.io/en/latest/?badge=latest)
    
 
-A python implementation of the web assembly interpreter
+A python implementation of the WebAssembly interpreter
 
 Read more in the [documentation on ReadTheDocs](https://py-wasm.readthedocs.io/). [View the change log](https://py-wasm.readthedocs.io/en/latest/releases.html).
 
@@ -106,7 +106,7 @@ The test suite in this library is run using `pytest`.
 pytest tests/
 ```
 
-Part of the test suite includes the *spec* tests from the official Web Assembly
+Part of the test suite includes the *spec* tests from the official WebAssembly
 spec.  These are found under `./tests/spec`.
 
 It is often useful to view logging output when running tests.  This can be done with:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,7 +254,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', 'py-wasm', 'py-wasm Documentation',
-   'Jason Carver', 'py-wasm', 'A python implementation of the web assembly interpreter',
+   'Jason Carver', 'py-wasm', 'A python implementation of the WebAssembly interpreter',
    'Miscellaneous'),
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 py-wasm
 ==============================
 
-A python implementation of the web assembly interpreter
+A python implementation of the WebAssembly interpreter
 
 Contents
 --------

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     name='py-wasm',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version='0.1.0-alpha.0',
-    description="""py-wasm: A python implementation of the web assembly interpreter""",
+    description="""py-wasm: A python implementation of the WebAssembly interpreter""",
     long_description_markdown_filename='README.md',
     author='Jason Carver',
     author_email='ethcalibur+pip@gmail.com',

--- a/wasm/__init__.py
+++ b/wasm/__init__.py
@@ -9,7 +9,7 @@ from .execution import (  # noqa: F401
 
 if sys.byteorder != 'little':
     raise ImportError(
-        f"Web assembly operates on little endian encoded values. This library's "
+        f"WebAssembly operates on little endian encoded values. This library's "
         f"use of numpy uses the system's endianness.  The current system's "
         f"endianness is {sys.byteorder} which isn't compatible."
     )

--- a/wasm/execution/configuration.py
+++ b/wasm/execution/configuration.py
@@ -39,7 +39,7 @@ from .stack import (
 
 class BaseConfiguration(ABC):
     """
-    Base class for the Configuration object used for execution Web Assembly
+    Base class for the Configuration object used for execution WebAssembly
     """
     store: Store
     current_instruction: BaseInstruction

--- a/wasm/execution/instructions.py
+++ b/wasm/execution/instructions.py
@@ -15,7 +15,7 @@ from wasm.instructions import (
 
 class InstructionSequence(Sequence):
     """
-    Stateful stream of instructions for web assembly execution.
+    Stateful stream of instructions for WebAssembly execution.
     """
     _instructions: Tuple[BaseInstruction, ...]
 

--- a/wasm/execution/runtime.py
+++ b/wasm/execution/runtime.py
@@ -183,7 +183,7 @@ def _compute_data_offsets(store: Store,
 
 class Runtime:
     """
-    Represents the *runtime* for the py-wasm Web Assembly interpreter.
+    Represents the *runtime* for the py-wasm WebAssembly interpreter.
     """
     store: Store
     modules: Dict[str, ModuleInstance]
@@ -217,7 +217,7 @@ class Runtime:
 
     def load_module(self, file_path: Path) -> Module:
         """
-        Load a Web Assembly module from its binary source file.
+        Load a WebAssembly module from its binary source file.
         """
         if file_path.suffix != ".wasm":
             raise Exception("Unsupported file type: {file_path.suffix}")
@@ -237,7 +237,7 @@ class Runtime:
 
     def load_buffer(self, buffer: IO) -> Module:
         """
-        Load a Web Assembly module from its binary source file.
+        Load a WebAssembly module from its binary source file.
         """
         try:
             module = parse_module(buffer)
@@ -255,7 +255,7 @@ class Runtime:
                            module: Module,
                            ) -> Tuple[ModuleInstance, Optional[Tuple[TValue, ...]]]:
         """
-        Instantiate a Web Assembly module into this runtime environment.
+        Instantiate a WebAssembly module into this runtime environment.
         """
         # Ensure the module is valid
         try:

--- a/wasm/execution/stack.py
+++ b/wasm/execution/stack.py
@@ -26,7 +26,7 @@ from .instructions import (
 
 class OperandStack(BaseStack[TValue]):
     """
-    A stack used for operands during Web Assembly execution
+    A stack used for operands during WebAssembly execution
     """
     pass
 
@@ -67,7 +67,7 @@ class Label:
 
 class ControlStack(BaseStack[Label]):
     """
-    A stack used for labels during Web Assembly execution
+    A stack used for labels during WebAssembly execution
     """
     def get_label_by_idx(self, key: LabelIdx) -> Label:
         return self._stack[-1 * (key + 1)]
@@ -138,6 +138,6 @@ class Frame:
 
 class FrameStack(BaseStack[Frame]):
     """
-    A stack used for frames during Web Assembly execution
+    A stack used for frames during WebAssembly execution
     """
     pass

--- a/wasm/parsers/magic.py
+++ b/wasm/parsers/magic.py
@@ -18,7 +18,7 @@ MAGIC = (numpy.uint8(0x00), numpy.uint8(0x61), numpy.uint8(0x73), numpy.uint8(0x
 
 def parse_magic(stream: IO[bytes]) -> Tuple[numpy.uint8, numpy.uint8, numpy.uint8, numpy.uint8]:
     """
-    Parser for the *magic* 4-byte preamble for a binary encoded Web Assembly module.
+    Parser for the *magic* 4-byte preamble for a binary encoded WebAssembly module.
 
     https://webassembly.github.io/spec/core/bikeshed/index.html#binary-magic
     """

--- a/wasm/parsers/sections.py
+++ b/wasm/parsers/sections.py
@@ -238,7 +238,7 @@ def normalize_sections(sections: Tuple[SECTION_TYPES, ...]) -> T_SECTIONS:
 
 def parse_sections(stream: IO[bytes]) -> T_SECTIONS:
     """
-    Parse the sections of a Web Assembly module.
+    Parse the sections of a WebAssembly module.
     """
     sections = _parse_sections(stream)
     return normalize_sections(sections)

--- a/wasm/parsers/version.py
+++ b/wasm/parsers/version.py
@@ -23,7 +23,7 @@ KNOWN_VERSIONS = {
 
 def parse_version(stream: IO[bytes]) -> Tuple[numpy.uint8, numpy.uint8, numpy.uint8, numpy.uint8]:
     """
-    Parser for the version portion of a binary encoded Web Assembly module
+    Parser for the version portion of a binary encoded WebAssembly module
     https://webassembly.github.io/spec/core/bikeshed/index.html#binary-version
     """
     actual = (

--- a/wasm/validation/modules.py
+++ b/wasm/validation/modules.py
@@ -146,7 +146,7 @@ def validate_function_types(module: Module) -> None:
 
 def validate_module(module: Module) -> Tuple[Tuple[TExtern, ...], Tuple[TExtern, ...]]:
     """
-    Validatie a web Assembly module.
+    Validatie a webAssembly module.
     """
     validate_function_types(module)
 

--- a/wasm/validation/version.py
+++ b/wasm/validation/version.py
@@ -16,7 +16,7 @@ TVersion = Tuple[numpy.uint8, numpy.uint8, numpy.uint8, numpy.uint8]
 
 def validate_version(version: TVersion) -> None:
     """
-    Validate the parsed version string for a Web Assembly module.
+    Validate the parsed version string for a WebAssembly module.
     """
     if version != constants.VERSION_1:
         raise ValidationError(


### PR DESCRIPTION
## What was wrong?

[WebAssembly](https://webassembly.org/) is spelled incorrectly.
